### PR TITLE
Fixed errors with compose.yml name and nginx.conf

### DIFF
--- a/Go_Refined_Code/Compose.yml
+++ b/Go_Refined_Code/Compose.yml
@@ -13,7 +13,7 @@ services:
   frontend-proxy:
     image: nginx:alpine
     ports:
-      - "127.0.0.1:80:80"  
+      - "127.0.0.1:8081:80"  
     volumes:
       - ./static:/usr/share/nginx/html:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend proxy service to listen on port 8081 instead of port 80

<!-- end of auto-generated comment: release notes by coderabbit.ai -->