### PR TITLE
Add Discord notification on CI failure

### DIFF
--- a/.github/workflows/ci_fail_discord
+++ b/.github/workflows/ci_fail_discord
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # --- Your existing CI steps go here ---
+      - name: Run tests
+        run: |
+          echo "Run your tests here"
+
+      # This step only runs if something above failed
+      - name: Notify Discord on failure
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          curl -H "Content-Type: application/json" \
+          -d "{
+            \"embeds\": [{
+              \"title\": \"❌ CI Failed\",
+              \"description\": \"**Repo:** ${{ github.repository }}\n**Branch:** ${{ github.ref_name }}\n**Commit:** ${{ github.sha }}\n**Triggered by:** ${{ github.actor }}\",
+              \"color\": 15158332,
+              \"url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
+            }]
+          }" \
+          $DISCORD_WEBHOOK


### PR DESCRIPTION
This workflow sends a notification to Discord if the CI fails, providing details about the repository, branch, commit, and the user who triggered the action.

## State your changes
[Describe what you changed]

## Why was this necessary?
[Explain the reason or problem this PR solves]

## Checklist
- [ ] Documentation
- [ ] Fixed bugs
- [ ] Added functionality
- [ ] Refactoring
- [ ] CI/CD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration workflow that automatically runs tests on repository updates and sends failure notifications to the development team for faster issue resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->