### PR TITLE
Update appleboy SSH action version in CD workflow

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -63,7 +63,7 @@ jobs:
     needs: build-and-push
     steps:
       - name: 🚀 Deploy to server
-        uses: appleboy/ssh-action@b60142998894e495c513803efc6d5d72a72c968a
+        uses: appleboy/ssh-action@b0ff4204d59e8e51228ff73bce53f80d53301dee2
         with:
           host: ${{ secrets.SERVER_IP }}
           username: ${{ secrets.SERVER_USER }}


### PR DESCRIPTION
## State your changes
[Describe what you changed]

updated the appleboy ssh/action-hash pin

## Why was this necessary?
[Explain the reason or problem this PR solves]

Maybe that was the issue with the shh-handshake on the server. 

## Checklist
- [ ] Documentation
- [ x] Fixed bugs
- [ ] Added functionality
- [ ] Refactoring
- [ ] CI/CD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow infrastructure with a newer version of the deployment action to maintain security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->