### PR TITLE
Add favicon to all pages (#115)

### DIFF
--- a/Go_Refined_Code/static/html/about.html
+++ b/Go_Refined_Code/static/html/about.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/png" href="/monkgroup.png">
 </head>
 
 <body>

--- a/Go_Refined_Code/static/html/index.html
+++ b/Go_Refined_Code/static/html/index.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/png" href="/monkgroup.png">
 </head>
 
 <body>

--- a/Go_Refined_Code/static/html/login.html
+++ b/Go_Refined_Code/static/html/login.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/png" href="/monkgroup.png">
 </head>
 
 <body>

--- a/Go_Refined_Code/static/html/register.html
+++ b/Go_Refined_Code/static/html/register.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/png" href="/monkgroup.png">
 </head>
 
 <body>


### PR DESCRIPTION
## State your changes
Added `<link rel="icon" type="image/png" href="/monkgroup.png">` to the `<head>` of all four HTML pages (index, login, register, about), using the existing `monkgroup.png` asset.

## Why was this necessary?
The site had no favicon, making it look unfinished in browser tabs. Fixes #115.

## Checklist
- [ ] Documentation
- [ ] Fixed bugs
- [x] Added functionality
- [ ] Refactoring
- [ ] CI/CD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added favicon to all major application pages for consistent brand display in browser tabs and address bars, enhancing visual identity and user recognition throughout the experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->