### PR TITLE
Replace alert() with inline notifications (#86)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Claude Code
+.claude/
+CLAUDE.md
+Go_Refined_Code/.claude/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Go_Refined_Code/static/javaScript/login_page_script.js
+++ b/Go_Refined_Code/static/javaScript/login_page_script.js
@@ -1,27 +1,23 @@
 import { callLoginRestApi } from "./api_calls.js";
-import { checkIfLoggedIn, createErrorElement, createSuccessElement } from "./reuseable_functions.js";
+import { checkIfLoggedIn, showError, showSuccess } from "./reuseable_functions.js";
 
 checkIfLoggedIn()
 
 const loginForm = document.getElementById('login-form');
-const body = document.getElementById("body")
-
 
 loginForm.addEventListener('submit', (e) => {
-    e.preventDefault(); // Stop the browser from reloading the page
+    e.preventDefault();
 
-    // Grab the values using the IDs we just added
     const userVal = document.getElementById('username').value;
     const passVal = document.getElementById('password').value;
 
-    // Call your function (from the previous step)
     callLoginRestApi(userVal, passVal)
         .then(data => {
             localStorage.setItem("token", data.token);
-            body.prepend(createSuccessElement("Login successful! Redirecting..."));
+            showSuccess("Login successful! Redirecting...");
             setTimeout(() => { window.location.href = "/"; }, 1500);
         })
         .catch(err => {
-            body.prepend(createErrorElement(err.message));
+            showError(err.message);
         });
 });

--- a/Go_Refined_Code/static/javaScript/login_page_script.js
+++ b/Go_Refined_Code/static/javaScript/login_page_script.js
@@ -1,5 +1,5 @@
 import { callLoginRestApi } from "./api_calls.js";
-import { checkIfLoggedIn, createErrorElement } from "./reuseable_functions.js";
+import { checkIfLoggedIn, createErrorElement, createSuccessElement } from "./reuseable_functions.js";
 
 checkIfLoggedIn()
 
@@ -17,12 +17,11 @@ loginForm.addEventListener('submit', (e) => {
     // Call your function (from the previous step)
     callLoginRestApi(userVal, passVal)
         .then(data => {
-            localStorage.setItem("token",data.token)
-
-            alert("Login Successful!");
-            window.location.href = "/"; // Redirect manually after success
+            localStorage.setItem("token", data.token);
+            body.prepend(createSuccessElement("Login successful! Redirecting..."));
+            setTimeout(() => { window.location.href = "/"; }, 1500);
         })
         .catch(err => {
-            body.prepend(createErrorElement(err.message))
+            body.prepend(createErrorElement(err.message));
         });
 });

--- a/Go_Refined_Code/static/javaScript/register_page_script.js
+++ b/Go_Refined_Code/static/javaScript/register_page_script.js
@@ -1,7 +1,7 @@
 
 
 import { callRegisterRestApi } from "./api_calls.js";
-import { checkIfLoggedIn, createErrorElement } from "./reuseable_functions.js";
+import { checkIfLoggedIn, createErrorElement, createSuccessElement } from "./reuseable_functions.js";
 
 const registerForm = document.getElementById('register-form');
 const body = document.getElementById("body")
@@ -21,16 +21,17 @@ if (registerForm) {
         };
 
         if (userData.password !== userData.password2) {
-           return alert("Passwords dont match");
+            body.prepend(createErrorElement("Passwords don't match"));
+            return;
         }
 
         callRegisterRestApi(userData)
             .then(_data => {
-                alert("Account created! Please log in.");
-                window.location.href = "/login";
+                body.prepend(createSuccessElement("Account created! Redirecting to login..."));
+                setTimeout(() => { window.location.href = "/login"; }, 1500);
             })
             .catch(err => {
-                body.prepend(createErrorElement(err.message))
+                body.prepend(createErrorElement(err.message));
             });
     });
 }

--- a/Go_Refined_Code/static/javaScript/register_page_script.js
+++ b/Go_Refined_Code/static/javaScript/register_page_script.js
@@ -1,11 +1,9 @@
 
 
 import { callRegisterRestApi } from "./api_calls.js";
-import { checkIfLoggedIn, createErrorElement, createSuccessElement } from "./reuseable_functions.js";
+import { checkIfLoggedIn, showError, showSuccess } from "./reuseable_functions.js";
 
 const registerForm = document.getElementById('register-form');
-const body = document.getElementById("body")
-
 
 checkIfLoggedIn()
 
@@ -21,17 +19,17 @@ if (registerForm) {
         };
 
         if (userData.password !== userData.password2) {
-            body.prepend(createErrorElement("Passwords don't match"));
+            showError("Passwords don't match");
             return;
         }
 
         callRegisterRestApi(userData)
             .then(_data => {
-                body.prepend(createSuccessElement("Account created! Redirecting to login..."));
+                showSuccess("Account created! Redirecting to login...");
                 setTimeout(() => { window.location.href = "/login"; }, 1500);
             })
             .catch(err => {
-                body.prepend(createErrorElement(err.message));
+                showError(err.message);
             });
     });
 }

--- a/Go_Refined_Code/static/javaScript/reuseable_functions.js
+++ b/Go_Refined_Code/static/javaScript/reuseable_functions.js
@@ -37,9 +37,17 @@ export function createErrorElement(message) {
     const div = document.createElement('div');
     div.className = 'error';
     const strong = document.createElement('strong');
-    strong.textContent = message; 
+    strong.textContent = message;
     div.appendChild(strong);
-    
+    return div;
+}
+
+export function createSuccessElement(message) {
+    const div = document.createElement('div');
+    div.className = 'success';
+    const strong = document.createElement('strong');
+    strong.textContent = message;
+    div.appendChild(strong);
     return div;
 }
 

--- a/Go_Refined_Code/static/javaScript/reuseable_functions.js
+++ b/Go_Refined_Code/static/javaScript/reuseable_functions.js
@@ -33,22 +33,56 @@ function logout() {
     window.location.href = "/";
 }
 
-export function createErrorElement(message) {
-    const div = document.createElement('div');
-    div.className = 'error';
-    const strong = document.createElement('strong');
-    strong.textContent = message;
-    div.appendChild(strong);
-    return div;
+const TOAST_DURATION = 4000;
+
+function getToastContainer() {
+    let container = document.getElementById('toast-container');
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'toast-container';
+        document.body.appendChild(container);
+    }
+    return container;
 }
 
-export function createSuccessElement(message) {
-    const div = document.createElement('div');
-    div.className = 'success';
-    const strong = document.createElement('strong');
-    strong.textContent = message;
-    div.appendChild(strong);
-    return div;
+function showToast(message, type) {
+    const container = getToastContainer();
+
+    const toast = document.createElement('div');
+    toast.className = `toast toast--${type}`;
+
+    const icon = document.createElement('span');
+    icon.className = 'toast__icon';
+    icon.textContent = type === 'success' ? '✓' : '✕';
+
+    const text = document.createElement('span');
+    text.className = 'toast__message';
+    text.textContent = message;
+
+    const close = document.createElement('button');
+    close.className = 'toast__close';
+    close.setAttribute('aria-label', 'Dismiss');
+    close.textContent = '×';
+
+    const progress = document.createElement('div');
+    progress.className = 'toast__progress';
+
+    toast.appendChild(icon);
+    toast.appendChild(text);
+    toast.appendChild(close);
+    toast.appendChild(progress);
+    container.appendChild(toast);
+
+    const dismiss = () => {
+        toast.classList.add('toast--out');
+        toast.addEventListener('animationend', () => toast.remove(), { once: true });
+    };
+
+    const timer = setTimeout(dismiss, TOAST_DURATION);
+    close.addEventListener('click', () => { clearTimeout(timer); dismiss(); });
 }
+
+export function showError(message) { showToast(message, 'error'); }
+export function showSuccess(message) { showToast(message, 'success'); }
 
 

--- a/Go_Refined_Code/static/style.css
+++ b/Go_Refined_Code/static/style.css
@@ -18,6 +18,8 @@
   --accent-ring: rgba(200, 169, 110, 0.22);
   --error:       #C26060;
   --error-bg:    rgba(194, 96, 96, 0.09);
+  --success:     #4f9e6f;
+  --success-bg:  rgba(79, 158, 111, 0.09);
   --success:     #4FA87A;
   --success-bg:  rgba(79, 168, 122, 0.09);
   --radius-sm:   5px;
@@ -430,6 +432,16 @@ div.error {
   padding: 11px 15px;
   font-size: 13.5px;
   color: var(--error);
+  margin-bottom: 16px;
+}
+
+div.success {
+  background: var(--success-bg);
+  border: 1px solid rgba(79, 158, 111, 0.25);
+  border-radius: var(--radius);
+  padding: 11px 15px;
+  font-size: 13.5px;
+  color: var(--success);
   margin-bottom: 16px;
 }
 

--- a/Go_Refined_Code/static/style.css
+++ b/Go_Refined_Code/static/style.css
@@ -18,8 +18,6 @@
   --accent-ring: rgba(200, 169, 110, 0.22);
   --error:       #C26060;
   --error-bg:    rgba(194, 96, 96, 0.09);
-  --success:     #4f9e6f;
-  --success-bg:  rgba(79, 158, 111, 0.09);
   --success:     #4FA87A;
   --success-bg:  rgba(79, 168, 122, 0.09);
   --radius-sm:   5px;
@@ -425,24 +423,145 @@ ul.flashes li {
   color: var(--success);
 }
 
-div.error {
-  background: var(--error-bg);
-  border: 1px solid rgba(194, 96, 96, 0.25);
-  border-radius: var(--radius);
-  padding: 11px 15px;
-  font-size: 13.5px;
-  color: var(--error);
-  margin-bottom: 16px;
+/* ── Toast Notifications ── */
+#toast-container {
+  position: fixed;
+  top: calc(var(--nav-h) + 16px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+  width: max-content;
+  max-width: min(400px, calc(100vw - 32px));
 }
 
-div.success {
-  background: var(--success-bg);
-  border: 1px solid rgba(79, 158, 111, 0.25);
+.toast {
+  pointer-events: all;
+  display: grid;
+  grid-template-columns: 28px 1fr 24px;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 14px;
   border-radius: var(--radius);
-  padding: 11px 15px;
-  font-size: 13.5px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  position: relative;
+  overflow: hidden;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.04);
+  border-left-width: 3px;
+  border-left-style: solid;
+  border-top: 1px solid;
+  border-right: 1px solid;
+  border-bottom: 1px solid;
+  animation: toast-in 0.35s cubic-bezier(0.34, 1.4, 0.64, 1) forwards;
+  min-width: 260px;
+}
+
+.toast--success {
+  background: rgba(16, 26, 22, 0.92);
+  border-color: rgba(79, 168, 122, 0.18);
+  border-left-color: var(--success);
+  color: #A8D9BC;
+}
+
+.toast--error {
+  background: rgba(24, 14, 14, 0.92);
+  border-color: rgba(194, 96, 96, 0.18);
+  border-left-color: var(--error);
+  color: #E09898;
+}
+
+.toast--out {
+  animation: toast-out 0.2s ease-in forwards;
+}
+
+.toast__icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.toast--success .toast__icon {
+  background: rgba(79, 168, 122, 0.15);
   color: var(--success);
-  margin-bottom: 16px;
+}
+
+.toast--error .toast__icon {
+  background: rgba(194, 96, 96, 0.15);
+  color: var(--error);
+}
+
+.toast__message {
+  line-height: 1.45;
+  color: inherit;
+}
+
+.toast__close {
+  background: transparent;
+  border: none;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0.35;
+  font-size: 16px;
+  line-height: 1;
+  color: inherit;
+  border-radius: var(--radius-sm);
+  transition: opacity var(--t), background var(--t);
+  flex-shrink: 0;
+  box-shadow: none;
+}
+
+.toast__close:hover {
+  opacity: 0.85;
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  box-shadow: none;
+}
+
+.toast__progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  border-radius: 0 1px 0 0;
+  opacity: 0.6;
+  animation: toast-progress 4s linear forwards;
+}
+
+.toast--success .toast__progress { background: var(--success); }
+.toast--error   .toast__progress { background: var(--error); }
+
+@keyframes toast-in {
+  from { transform: translateY(-16px) scale(0.97); opacity: 0; }
+  to   { transform: translateY(0)     scale(1);    opacity: 1; }
+}
+
+@keyframes toast-out {
+  from { transform: translateY(0)     scale(1);    opacity: 1; }
+  to   { transform: translateY(-8px)  scale(0.97); opacity: 0; }
+}
+
+@keyframes toast-progress {
+  from { width: 100%; }
+  to   { width: 0%; }
 }
 
 /* ── Footer ── */


### PR DESCRIPTION
## State your changes
Replaced all three browser `alert()` calls with inline styled notifications:
- Password mismatch on register → red error banner (reuses existing `createErrorElement`)
- Successful registration → green success banner, redirects to login after 1.5s
- Successful login → green success banner, redirects to home after 1.5s

Added `createSuccessElement` to `reuseable_functions.js` and matching `.success` CSS class + variables (`--success`, `--success-bg`) to `style.css`.

## Why was this necessary?
Browser `alert()` dialogs are jarring, block the page, and look unprofessional. Fixes #86.

## Checklist
- [ ] Documentation
- [ ] Fixed bugs
- [x] Added functionality
- [ ] Refactoring
- [ ] CI/CD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast-style success/error notifications for in-page feedback.

* **Improvements**
  * Replaced browser alerts and legacy inline error blocks with unified toast UI.
  * Replaced immediate redirects with 1.5s “success, redirecting…” messages before navigation.

* **Style**
  * Added toast styles, animations, icons, close control, and progress indicator; removed old error styling.

* **Chores**
  * Updated ignore rules to exclude local tooling artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->