### PR TITLE
feat: auto-create GitHub release on every push to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate tag
+        id: tag
+        run: |
+          DATE=$(date +'%Y.%m.%d')
+          SHA=$(git rev-parse --short HEAD)
+          echo "name=v${DATE}-${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Adds a new `release.yaml` workflow that triggers on every push to `main`
- Generates a version tag in the format `vYYYY.MM.DD-<short-sha>` (e.g. `v2026.04.15-d1f66ab`)
- Creates a GitHub Release using `softprops/action-gh-release@v2` with auto-generated release notes from commit history

## Test plan
- [ ] Merge this PR and confirm a new release appears under the Releases tab
- [ ] Verify the tag format matches `vYYYY.MM.DD-<sha>`
- [ ] Verify auto-generated release notes list the merged commits

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release workflow for efficient and consistent release management, including automatic release note generation on main branch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->