### PR TITLE
feat: handle security breach — change-password, breach warning, Resend emails

### DIFF
--- a/Go_Refined_Code/handlers/authApi.go
+++ b/Go_Refined_Code/handlers/authApi.go
@@ -139,6 +139,7 @@ func HandleAPILogin(db *sql.DB) http.HandlerFunc {
 			StatusCode: 200,
 			Message:    "Login successful",
 			Token:      tokenString,
+			Breached:   isBreached(req.Username, req.Password),
 		})
 
 		if err != nil {

--- a/Go_Refined_Code/handlers/breachList.go
+++ b/Go_Refined_Code/handlers/breachList.go
@@ -1,0 +1,32 @@
+// Package handlers breachList
+package handlers
+
+// breachedCredentials maps breached usernames to their leaked plaintext passwords.
+var breachedCredentials = map[string]string{ //nolint:gochecknoglobals
+	"Benthe1954":    "^Jt^pLkzW2",
+	"Jack1969":      "_yRw7uqk4h",
+	"Pernille1949":  "^e3cTMrM4p",
+	"Elna1996":      "t8YYsYRu$0",
+	"Charlotte2020": ")1EFaslG$O",
+	"Hans1965":      "YY0Bihn%g$",
+	"Hanne2000":     "EpHYH0Vie(",
+	"Doris1985":     "ziTGrweO^4",
+	"Naja1991":      "Ne%1GsjYgx",
+	"Albert1966":    "HCN2@Nw1@#",
+	"Weena1968":     "@8XXVyc#*4",
+	"Emil2002":      "$3mLd3ui3V",
+	"Uffe1985":      "Qv33LISxU(",
+	"Stephan1949":   "EozcbEk@&5",
+	"Hannah1983":    "*$ow)Kub*9",
+	"Jarl2024":      "^U1qZ(0ryO",
+	"Boe1991":       "4v)8Wsr$FJ",
+	"Sine2008":      "zNI#3G4sL%",
+	"Olivia1968":    "^_Sno42&m5",
+	"Abelone1972":   "YM*43dDbR)",
+}
+
+// isBreached reports whether the username/password pair was in the production breach.
+func isBreached(username, password string) bool {
+	leaked, ok := breachedCredentials[username]
+	return ok && leaked == password
+}

--- a/Go_Refined_Code/handlers/breach_test.go
+++ b/Go_Refined_Code/handlers/breach_test.go
@@ -1,0 +1,29 @@
+package handlers
+
+import "testing"
+
+func TestIsBreached_KnownPair(t *testing.T) {
+	if !isBreached("Benthe1954", "^Jt^pLkzW2") {
+		t.Error("expected known pair to be breached")
+	}
+}
+
+func TestIsBreached_WrongPassword(t *testing.T) {
+	if isBreached("Benthe1954", "wrongpassword") {
+		t.Error("expected wrong password to not be breached")
+	}
+}
+
+func TestIsBreached_UnknownUser(t *testing.T) {
+	if isBreached("unknownuser", "^Jt^pLkzW2") {
+		t.Error("expected unknown user to not be breached")
+	}
+}
+
+func TestIsBreached_AllPairs(t *testing.T) {
+	for username, password := range breachedCredentials {
+		if !isBreached(username, password) {
+			t.Errorf("expected %s to be breached with correct password", username)
+		}
+	}
+}

--- a/Go_Refined_Code/handlers/emailService.go
+++ b/Go_Refined_Code/handlers/emailService.go
@@ -1,0 +1,99 @@
+// Package handlers emailService
+package handlers
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+// resendBaseURL is the Resend API endpoint. Overridden in tests.
+var resendBaseURL = "https://api.resend.com" //nolint:gochecknoglobals
+
+type resendPayload struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	HTML    string   `json:"html"`
+}
+
+// SendBreachNotification sends a single breach notification email via Resend.
+func SendBreachNotification(apiKey, fromEmail, toEmail, username string) error {
+	body := resendPayload{
+		From:    fromEmail,
+		To:      []string{toEmail},
+		Subject: "Important: Your account credentials were exposed",
+		HTML: fmt.Sprintf(`
+<p>Dear %s,</p>
+<p>We are writing to inform you that your account credentials were included in a data breach of our production database.</p>
+<p>Your username and password were exposed. We strongly recommend that you:</p>
+<ul>
+  <li><strong>Change your password immediately</strong> at <a href="https://whoknows.example.com/profile">whoknows.example.com/profile</a></li>
+  <li>Change your password on any other site where you used the same password</li>
+</ul>
+<p>We sincerely apologize for this incident.</p>
+<p>— The ¿Who Knows? Team</p>
+`, username),
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal email payload: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, resendBaseURL+"/emails", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("resend API returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// SendBreachNotificationsToAll looks up each breached username in the DB and
+// sends a notification email. Requires RESEND_API_KEY and RESEND_FROM_EMAIL env vars.
+func SendBreachNotificationsToAll(db *sql.DB) {
+	apiKey := os.Getenv("RESEND_API_KEY")
+	fromEmail := os.Getenv("RESEND_FROM_EMAIL")
+	if apiKey == "" {
+		log.Println("SendBreachNotificationsToAll: RESEND_API_KEY not set, skipping")
+		return
+	}
+	if fromEmail == "" {
+		log.Println("SendBreachNotificationsToAll: RESEND_FROM_EMAIL not set, skipping")
+		return
+	}
+
+	for username := range breachedCredentials {
+		var email string
+		err := db.QueryRow("SELECT email FROM users WHERE username = ?", username).Scan(&email)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			log.Printf("SendBreachNotificationsToAll: DB error for %s: %v", username, err)
+			continue
+		}
+
+		if err := SendBreachNotification(apiKey, fromEmail, email, username); err != nil {
+			log.Printf("SendBreachNotificationsToAll: failed to notify %s: %v", username, err)
+		} else {
+			log.Printf("SendBreachNotificationsToAll: notified %s (%s)", username, email)
+		}
+	}
+}

--- a/Go_Refined_Code/handlers/email_test.go
+++ b/Go_Refined_Code/handlers/email_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSendBreachNotification_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("unexpected Authorization header: %s", r.Header.Get("Authorization"))
+		}
+		var payload resendPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode payload: %v", err)
+		}
+		if len(payload.To) == 0 || payload.To[0] != "victim@example.com" {
+			t.Errorf("unexpected To: %v", payload.To)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resendBaseURL = srv.URL
+	t.Cleanup(func() { resendBaseURL = "https://api.resend.com" })
+
+	err := SendBreachNotification("test-key", "noreply@example.com", "victim@example.com", "Benthe1954")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSendBreachNotification_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	resendBaseURL = srv.URL
+	t.Cleanup(func() { resendBaseURL = "https://api.resend.com" })
+
+	err := SendBreachNotification("bad-key", "from@example.com", "to@example.com", "Jack1969")
+	if err == nil {
+		t.Error("expected error on 401 response")
+	}
+}
+
+func TestSendBreachNotificationsToAll_SkipsWhenNoAPIKey(t *testing.T) {
+	db := newUsersDB(t)
+	// Should log and return without error when RESEND_API_KEY is not set
+	t.Setenv("RESEND_API_KEY", "")
+	SendBreachNotificationsToAll(db) // must not panic
+}
+
+func TestSendBreachNotificationsToAll_SendsToKnownUsers(t *testing.T) {
+	notified := map[string]bool{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload resendPayload
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		if len(payload.To) > 0 {
+			notified[payload.To[0]] = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resendBaseURL = srv.URL
+	t.Cleanup(func() { resendBaseURL = "https://api.resend.com" })
+
+	t.Setenv("RESEND_API_KEY", "test-key")
+	t.Setenv("RESEND_FROM_EMAIL", "noreply@example.com")
+
+	db := newUsersDB(t)
+	seedUser(t, db, "Benthe1954", "benthe@example.com", "somepass")
+	seedUser(t, db, "Jack1969", "jack@example.com", "somepass")
+
+	SendBreachNotificationsToAll(db)
+
+	if !notified["benthe@example.com"] {
+		t.Error("expected benthe@example.com to be notified")
+	}
+	if !notified["jack@example.com"] {
+		t.Error("expected jack@example.com to be notified")
+	}
+}

--- a/Go_Refined_Code/handlers/profileApi.go
+++ b/Go_Refined_Code/handlers/profileApi.go
@@ -1,0 +1,80 @@
+// Package handlers profileApi
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// parseJWT extracts and validates the JWT from the Authorization header.
+func parseJWT(r *http.Request) (*Claims, error) {
+	authHeader := r.Header.Get("Authorization")
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+
+	claims := &Claims{}
+	_, err := jwt.ParseWithClaims(tokenString, claims, func(_ *jwt.Token) (any, error) {
+		return jwtKey, nil
+	})
+	return claims, err
+}
+
+// HandleAPIChangePassword POST /api/change-password
+func HandleAPIChangePassword(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		claims, err := parseJWT(r)
+		if err != nil {
+			sendJSON(w, http.StatusUnauthorized, "Invalid or missing token")
+			return
+		}
+
+		var req struct {
+			CurrentPassword string `json:"current_password"` //nolint:gosec
+			NewPassword     string `json:"new_password"`     //nolint:gosec
+			NewPassword2    string `json:"new_password2"`    //nolint:gosec
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			sendJSON(w, http.StatusBadRequest, "Invalid JSON body")
+			return
+		}
+
+		if req.NewPassword != req.NewPassword2 {
+			sendJSON(w, http.StatusUnprocessableEntity, "Passwords do not match")
+			return
+		}
+
+		var hashedPw string
+		err = db.QueryRow("SELECT password FROM users WHERE id = ?", claims.UserID).Scan(&hashedPw)
+		if err == sql.ErrNoRows {
+			sendJSON(w, http.StatusUnauthorized, "User not found")
+			return
+		}
+		if err != nil {
+			sendJSON(w, http.StatusInternalServerError, "Internal server error")
+			return
+		}
+
+		if !verifyPassword(req.CurrentPassword, hashedPw) {
+			sendJSON(w, http.StatusUnauthorized, "Current password is incorrect")
+			return
+		}
+
+		newHash, err := hashPassword(req.NewPassword)
+		if err != nil {
+			sendJSON(w, http.StatusInternalServerError, "Internal server error")
+			return
+		}
+
+		_, err = db.Exec("UPDATE users SET password = ? WHERE id = ?", newHash, claims.UserID)
+		if err != nil {
+			sendJSON(w, http.StatusInternalServerError, "Internal server error")
+			return
+		}
+
+		sendJSON(w, http.StatusOK, "Password updated successfully")
+	}
+}

--- a/Go_Refined_Code/handlers/profile_test.go
+++ b/Go_Refined_Code/handlers/profile_test.go
@@ -1,0 +1,171 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// makeToken creates a signed JWT for the given userID, using the package-level jwtKey.
+func makeToken(t *testing.T, userID int) string {
+	t.Helper()
+	claims := &Claims{
+		UserID: userID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(jwtKey)
+	if err != nil {
+		t.Fatalf("makeToken: %v", err)
+	}
+	return signed
+}
+
+func TestHandleAPIChangePassword_Success(t *testing.T) {
+	db := newUsersDB(t)
+	seedUser(t, db, "frank", "frank@example.com", "oldpass")
+
+	var userID int
+	_ = db.QueryRow("SELECT id FROM users WHERE username = ?", "frank").Scan(&userID)
+	token := makeToken(t, userID)
+
+	body := `{"current_password":"oldpass","new_password":"newpass","new_password2":"newpass"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/change-password", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	w := httptest.NewRecorder()
+
+	HandleAPIChangePassword(db)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleAPIChangePassword_WrongCurrentPassword(t *testing.T) {
+	db := newUsersDB(t)
+	seedUser(t, db, "grace", "grace@example.com", "correct")
+
+	var userID int
+	_ = db.QueryRow("SELECT id FROM users WHERE username = ?", "grace").Scan(&userID)
+	token := makeToken(t, userID)
+
+	body := `{"current_password":"wrong","new_password":"new","new_password2":"new"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/change-password", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	w := httptest.NewRecorder()
+
+	HandleAPIChangePassword(db)(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleAPIChangePassword_PasswordMismatch(t *testing.T) {
+	db := newUsersDB(t)
+	seedUser(t, db, "henry", "henry@example.com", "pass")
+
+	var userID int
+	_ = db.QueryRow("SELECT id FROM users WHERE username = ?", "henry").Scan(&userID)
+	token := makeToken(t, userID)
+
+	body := `{"current_password":"pass","new_password":"abc","new_password2":"xyz"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/change-password", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	w := httptest.NewRecorder()
+
+	HandleAPIChangePassword(db)(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", w.Code)
+	}
+}
+
+func TestHandleAPIChangePassword_NoToken(t *testing.T) {
+	db := newUsersDB(t)
+
+	body := `{"current_password":"a","new_password":"b","new_password2":"b"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/change-password", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+
+	HandleAPIChangePassword(db)(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleAPIChangePassword_InvalidJSON(t *testing.T) {
+	db := newUsersDB(t)
+	seedUser(t, db, "irma", "irma@example.com", "pass")
+
+	var userID int
+	_ = db.QueryRow("SELECT id FROM users WHERE username = ?", "irma").Scan(&userID)
+	token := makeToken(t, userID)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/change-password", bytes.NewBufferString("bad-json"))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	w := httptest.NewRecorder()
+
+	HandleAPIChangePassword(db)(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleAPILogin_BreachedFlagSet(t *testing.T) {
+	db := newUsersDB(t)
+	// Seed a breached user with their leaked password
+	seedUser(t, db, "Benthe1954", "benthe@example.com", "^Jt^pLkzW2")
+
+	body := `{"username":"Benthe1954","password":"^Jt^pLkzW2"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	HandleAPILogin(db)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp AuthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Breached {
+		t.Error("expected breached=true for a known breached user")
+	}
+}
+
+func TestHandleAPILogin_BreachedFlagNotSetForNormalUser(t *testing.T) {
+	db := newUsersDB(t)
+	seedUser(t, db, "normaluser", "normal@example.com", "safepassword")
+
+	body := `{"username":"normaluser","password":"safepassword"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/login", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	HandleAPILogin(db)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp AuthResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Breached {
+		t.Error("expected breached=false for a normal user")
+	}
+}

--- a/Go_Refined_Code/handlers/registerApi.go
+++ b/Go_Refined_Code/handlers/registerApi.go
@@ -20,4 +20,5 @@ type AuthResponse struct {
 	StatusCode int    `json:"statusCode"`
 	Message    string `json:"message"`
 	Token      string `json:"token"`
+	Breached   bool   `json:"breached,omitempty"`
 }

--- a/Go_Refined_Code/main.go
+++ b/Go_Refined_Code/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	cors "github.com/gorilla/handlers"
@@ -24,6 +25,10 @@ func main() {
 		log.Fatal(err)
 	}
 	database.PurgeMD5Users()
+
+	if os.Getenv("SEND_BREACH_EMAILS") == "true" {
+		go apiHandlers.SendBreachNotificationsToAll(database.DB)
+	}
 
 	// 3️⃣ Router
 	r := mux.NewRouter()

--- a/Go_Refined_Code/main.go
+++ b/Go_Refined_Code/main.go
@@ -35,6 +35,7 @@ func main() {
 	api.HandleFunc("/register", apiHandlers.HandleAPIRegister(database.DB)).Methods("POST")
 	api.HandleFunc("/login", apiHandlers.HandleAPILogin(database.DB)).Methods("POST")
 	api.HandleFunc("/logout", homeHandler).Methods("GET")
+	api.HandleFunc("/change-password", apiHandlers.HandleAPIChangePassword(database.DB)).Methods("POST")
 
 	// 4️⃣ Server
 	r.PathPrefix("/static/").Handler(

--- a/Go_Refined_Code/nginx.conf
+++ b/Go_Refined_Code/nginx.conf
@@ -29,6 +29,11 @@ server {
         try_files $uri /html/about.html =404;
     }
 
+    location /profile {
+        root /usr/share/nginx/html;
+        try_files $uri /html/profile.html =404;
+    }
+
     # 2. Proxy API requests to the Go container
     location /api/ {
         # 'go-backend' is the name of the service in docker-compose

--- a/Go_Refined_Code/static/html/profile.html
+++ b/Go_Refined_Code/static/html/profile.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="da">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Profile — ¿Who Knows?</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/png" href="/monkgroup.png">
+</head>
+
+<body>
+
+  <div class="page">
+    <div class="navigation">
+      <nav id="nav-bar">
+        <h1>
+          <a href="/">¿Who Knows?</a>
+        </h1>
+        <a id="nav-login" href="/login">Log in</a>
+        <a id="nav-register" href="/register">Register</a>
+      </nav>
+    </div>
+
+    <div class="body" id="body">
+      <div class="form-page">
+        <div class="form-container">
+
+          <div id="breach-warning" style="display:none" class="breach-banner">
+            <strong>Security alert:</strong> Your account credentials were exposed in a data breach.
+            Please change your password immediately.
+          </div>
+
+          <h2>Change password.</h2>
+          <p class="form-sub">Keep your account secure.</p>
+          <span class="accent-line"></span>
+
+          <form id="change-password-form">
+            <dl>
+              <div>
+                <dt>Current password</dt>
+                <dd>
+                  <input type="password" id="current-password" size="30" placeholder="••••••••" required>
+                </dd>
+              </div>
+
+              <div>
+                <dt>New password</dt>
+                <dd>
+                  <input type="password" id="new-password" size="30" placeholder="••••••••" required>
+                </dd>
+              </div>
+
+              <div>
+                <dt>New password <small>(repeat)</small></dt>
+                <dd>
+                  <input type="password" id="new-password-confirm" size="30" placeholder="••••••••" required>
+                </dd>
+              </div>
+            </dl>
+            <div class="actions">
+              <input type="submit" id="change-password-button" value="Update Password">
+            </div>
+          </form>
+
+        </div>
+      </div>
+
+      <div class="footer">
+        <span>¿Who Knows? &copy; 2026</span>
+        <a href="/about">About</a>
+      </div>
+    </div>
+
+    <script src="../javaScript/profile_script.js" type="module"></script>
+  </div>
+</body>
+
+</html>

--- a/Go_Refined_Code/static/javaScript/api_calls.js
+++ b/Go_Refined_Code/static/javaScript/api_calls.js
@@ -38,6 +38,30 @@ export function callLoginRestApi(username, password) {
         });
 }
 
+export function callChangePasswordApi(currentPassword, newPassword, newPassword2) {
+    const token = localStorage.getItem("token");
+    return fetch("/api/change-password", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+            current_password: currentPassword,
+            new_password: newPassword,
+            new_password2: newPassword2,
+        }),
+    })
+        .then(response => {
+            if (!response.ok) {
+                return response.json().then(errData => {
+                    throw new Error(errData.message || `Request failed (${response.status})`);
+                });
+            }
+            return response.json();
+        });
+}
+
 export function callRegisterRestApi(userData) {
     return fetch(`/api/register`, {
         method: 'POST',

--- a/Go_Refined_Code/static/javaScript/login_page_script.js
+++ b/Go_Refined_Code/static/javaScript/login_page_script.js
@@ -15,8 +15,9 @@ loginForm.addEventListener('submit', (e) => {
         .then(data => {
             localStorage.setItem("token", data.token);
             if (data.breached) {
+                sessionStorage.setItem("breachWarning", "1");
                 showSuccess("Login successful! Your password was exposed — please change it now.");
-                setTimeout(() => { window.location.href = "/profile?breached=1"; }, 2000);
+                setTimeout(() => { window.location.href = "/profile"; }, 2000);
             } else {
                 showSuccess("Login successful! Redirecting...");
                 setTimeout(() => { window.location.href = "/"; }, 1500);

--- a/Go_Refined_Code/static/javaScript/login_page_script.js
+++ b/Go_Refined_Code/static/javaScript/login_page_script.js
@@ -14,8 +14,13 @@ loginForm.addEventListener('submit', (e) => {
     callLoginRestApi(userVal, passVal)
         .then(data => {
             localStorage.setItem("token", data.token);
-            showSuccess("Login successful! Redirecting...");
-            setTimeout(() => { window.location.href = "/"; }, 1500);
+            if (data.breached) {
+                showSuccess("Login successful! Your password was exposed — please change it now.");
+                setTimeout(() => { window.location.href = "/profile?breached=1"; }, 2000);
+            } else {
+                showSuccess("Login successful! Redirecting...");
+                setTimeout(() => { window.location.href = "/"; }, 1500);
+            }
         })
         .catch(err => {
             showError(err.message);

--- a/Go_Refined_Code/static/javaScript/profile_script.js
+++ b/Go_Refined_Code/static/javaScript/profile_script.js
@@ -1,0 +1,35 @@
+import { callChangePasswordApi } from "./api_calls.js";
+import { checkIfLoggedIn, showError, showSuccess } from "./reuseable_functions.js";
+
+checkIfLoggedIn();
+
+// Show breach warning if redirected from login with ?breached=1
+const params = new URLSearchParams(window.location.search);
+if (params.get("breached") === "1") {
+    document.getElementById("breach-warning").style.display = "block";
+}
+
+const form = document.getElementById("change-password-form");
+
+form.addEventListener("submit", (e) => {
+    e.preventDefault();
+
+    const currentPassword = document.getElementById("current-password").value;
+    const newPassword = document.getElementById("new-password").value;
+    const newPasswordConfirm = document.getElementById("new-password-confirm").value;
+
+    if (newPassword !== newPasswordConfirm) {
+        showError("New passwords do not match.");
+        return;
+    }
+
+    callChangePasswordApi(currentPassword, newPassword, newPasswordConfirm)
+        .then(() => {
+            document.getElementById("breach-warning").style.display = "none";
+            showSuccess("Password updated successfully!");
+            form.reset();
+        })
+        .catch((err) => {
+            showError(err.message);
+        });
+});

--- a/Go_Refined_Code/static/javaScript/profile_script.js
+++ b/Go_Refined_Code/static/javaScript/profile_script.js
@@ -1,6 +1,12 @@
 import { callChangePasswordApi } from "./api_calls.js";
 import { checkIfLoggedIn, showError, showSuccess } from "./reuseable_functions.js";
 
+// Auth guard — checkIfLoggedIn handles the redirect, but bail early so the
+// rest of the script doesn't run for unauthenticated users.
+if (!localStorage.getItem("token")) {
+    window.location.href = "/login";
+}
+
 checkIfLoggedIn();
 
 // Show breach warning if set by login redirect (sessionStorage) or ?breached=1 query param

--- a/Go_Refined_Code/static/javaScript/profile_script.js
+++ b/Go_Refined_Code/static/javaScript/profile_script.js
@@ -3,10 +3,11 @@ import { checkIfLoggedIn, showError, showSuccess } from "./reuseable_functions.j
 
 checkIfLoggedIn();
 
-// Show breach warning if redirected from login with ?breached=1
+// Show breach warning if set by login redirect (sessionStorage) or ?breached=1 query param
 const params = new URLSearchParams(window.location.search);
-if (params.get("breached") === "1") {
+if (sessionStorage.getItem("breachWarning") === "1" || params.get("breached") === "1") {
     document.getElementById("breach-warning").style.display = "block";
+    sessionStorage.removeItem("breachWarning");
 }
 
 const form = document.getElementById("change-password-form");

--- a/Go_Refined_Code/static/javaScript/reuseable_functions.js
+++ b/Go_Refined_Code/static/javaScript/reuseable_functions.js
@@ -2,34 +2,50 @@ const nav = document.getElementById("nav-bar");
 const navRegister = document.getElementById("nav-register");
 const navLogin = document.getElementById("nav-login");
 
-export function checkIfLoggedIn() {
+const isProfilePage = window.location.pathname.includes("profile");
 
+export function checkIfLoggedIn() {
     const token = localStorage.getItem('token');
 
-    if (token) {
-        // 1. Hide Login and Register
-        if (navLogin) navLogin.style.display = "none";
-        if (navRegister) navRegister.style.display = "none";
+    if (!token) {
+        // Unauthenticated user trying to access profile — send to login
+        if (isProfilePage) {
+            window.location.href = "/login";
+        }
+        return;
+    }
 
-        // 2. Create and Append Logout link
-        const logoutLink = document.createElement("a");
-        logoutLink.href = "#";
-        logoutLink.id = "nav-logout";
-        logoutLink.textContent = "Logout";
+    // 1. Hide Login and Register
+    if (navLogin) navLogin.style.display = "none";
+    if (navRegister) navRegister.style.display = "none";
 
-        logoutLink.addEventListener("click", (e) => {
-            e.preventDefault();
-            logout();
+    // 2. Add Profile link
+    const profileLink = document.createElement("a");
+    profileLink.href = "/profile";
+    profileLink.id = "nav-profile";
+    profileLink.textContent = "Profile";
+    nav.appendChild(profileLink);
 
-        });
+    // 3. Add Logout link
+    const logoutLink = document.createElement("a");
+    logoutLink.href = "#";
+    logoutLink.id = "nav-logout";
+    logoutLink.textContent = "Logout";
+    logoutLink.addEventListener("click", (e) => {
+        e.preventDefault();
+        logout();
+    });
+    nav.appendChild(logoutLink);
 
-        nav.appendChild(logoutLink);
+    // 4. Breach lockdown — breached users can only use the profile page
+    if (sessionStorage.getItem('breachWarning') === '1' && !isProfilePage) {
+        window.location.href = "/profile";
     }
 }
 
 function logout() {
-    // Simply remove the token and refresh
     localStorage.removeItem('token');
+    sessionStorage.removeItem('breachWarning');
     window.location.href = "/";
 }
 

--- a/Go_Refined_Code/static/style.css
+++ b/Go_Refined_Code/static/style.css
@@ -640,6 +640,18 @@ ul.flashes li {
   opacity: 0.7;
 }
 
+/* ── Breach Banner ── */
+.breach-banner {
+  background: rgba(194, 96, 96, 0.12);
+  border: 1px solid var(--error);
+  color: var(--error);
+  border-radius: var(--radius);
+  padding: 14px 18px;
+  margin-bottom: 28px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
 /* ── Responsive ── */
 @media (max-width: 600px) {
   nav { padding: 0 16px; }

--- a/Go_Refined_Code/tests/e2e/tests/profile.spec.js
+++ b/Go_Refined_Code/tests/e2e/tests/profile.spec.js
@@ -2,8 +2,23 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Profile page', () => {
+    test('redirects to /login when not authenticated', async ({ page }) => {
+        await page.goto('/html/profile.html');
+        await page.waitForURL('**/login**', { timeout: 5000 });
+        expect(page.url()).toContain('login');
+    });
+
+    test('shows profile page when authenticated', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('token', 'fake-jwt'));
+        await page.goto('/html/profile.html');
+        await expect(page.locator('#change-password-form')).toBeVisible();
+    });
+
     test('shows breach warning when breachWarning is set in sessionStorage', async ({ page }) => {
-        await page.addInitScript(() => sessionStorage.setItem('breachWarning', '1'));
+        await page.addInitScript(() => {
+            localStorage.setItem('token', 'fake-jwt');
+            sessionStorage.setItem('breachWarning', '1');
+        });
         await page.goto('/html/profile.html');
 
         const banner = page.locator('#breach-warning');
@@ -11,14 +26,14 @@ test.describe('Profile page', () => {
         await expect(banner).toContainText('Security alert');
     });
 
-    test('does not show breach warning without query param', async ({ page }) => {
+    test('does not show breach warning for normal logged-in user', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('token', 'fake-jwt'));
         await page.goto('/html/profile.html');
-
-        const banner = page.locator('#breach-warning');
-        await expect(banner).toBeHidden();
+        await expect(page.locator('#breach-warning')).toBeHidden();
     });
 
     test('change-password form submit triggers /api/change-password call', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('token', 'fake-jwt'));
         await page.route('/api/change-password', (route) =>
             route.fulfill({
                 status: 200,
@@ -48,10 +63,7 @@ test.describe('Profile page', () => {
     });
 
     test('change-password form sends Authorization header with token', async ({ page }) => {
-        await page.addInitScript(() => {
-            localStorage.setItem('token', 'test-jwt-token');
-        });
-
+        await page.addInitScript(() => localStorage.setItem('token', 'test-jwt-token'));
         await page.route('/api/change-password', (route) =>
             route.fulfill({
                 status: 200,
@@ -76,6 +88,7 @@ test.describe('Profile page', () => {
     });
 
     test('shows error toast on failed password change', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('token', 'fake-jwt'));
         await page.route('/api/change-password', (route) =>
             route.fulfill({
                 status: 401,
@@ -97,8 +110,10 @@ test.describe('Profile page', () => {
     });
 
     test('breach warning is hidden after successful password change', async ({ page }) => {
-        await page.addInitScript(() => sessionStorage.setItem('breachWarning', '1'));
-
+        await page.addInitScript(() => {
+            localStorage.setItem('token', 'fake-jwt');
+            sessionStorage.setItem('breachWarning', '1');
+        });
         await page.route('/api/change-password', (route) =>
             route.fulfill({
                 status: 200,
@@ -118,19 +133,53 @@ test.describe('Profile page', () => {
         await expect(page.locator('#breach-warning')).toBeHidden();
     });
 
-    test('nav login link href is /login', async ({ page }) => {
+    test('profile nav link is visible when logged in', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('token', 'fake-jwt'));
         await page.goto('/html/profile.html');
-        expect(await page.getAttribute('#nav-login', 'href')).toBe('/login');
+        const profileLink = page.locator('#nav-profile');
+        await expect(profileLink).toBeVisible();
+        expect(await profileLink.getAttribute('href')).toBe('/profile');
     });
 
-    test('nav register link href is /register', async ({ page }) => {
+    test('nav login/register links are hidden when logged in', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('token', 'fake-jwt'));
         await page.goto('/html/profile.html');
-        expect(await page.getAttribute('#nav-register', 'href')).toBe('/register');
+        await expect(page.locator('#nav-login')).toBeHidden();
+        await expect(page.locator('#nav-register')).toBeHidden();
+    });
+});
+
+test.describe('Breach lockdown', () => {
+    test('breached user is redirected from search page to profile', async ({ page }) => {
+        await page.addInitScript(() => {
+            localStorage.setItem('token', 'fake-jwt');
+            sessionStorage.setItem('breachWarning', '1');
+        });
+
+        await page.goto('/html/index.html');
+        await page.waitForURL('**/profile**', { timeout: 5000 });
+        expect(page.url()).toContain('profile');
+    });
+
+    test('non-breached logged-in user can access search page', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('token', 'fake-jwt'));
+        await page.goto('/html/index.html');
+        await expect(page.locator('#search-input')).toBeVisible();
+    });
+
+    test('breached user can access profile page to change password', async ({ page }) => {
+        await page.addInitScript(() => {
+            localStorage.setItem('token', 'fake-jwt');
+            sessionStorage.setItem('breachWarning', '1');
+        });
+        await page.goto('/html/profile.html');
+        await expect(page.locator('#change-password-form')).toBeVisible();
+        await expect(page.locator('#breach-warning')).toBeVisible();
     });
 });
 
 test.describe('Login page — breach redirect', () => {
-    test('redirects to /profile?breached=1 when breached flag is true', async ({ page }) => {
+    test('redirects to /profile when breached flag is true', async ({ page }) => {
         await page.route('/api/login', (route) =>
             route.fulfill({
                 status: 200,

--- a/Go_Refined_Code/tests/e2e/tests/profile.spec.js
+++ b/Go_Refined_Code/tests/e2e/tests/profile.spec.js
@@ -1,0 +1,178 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.describe('Profile page', () => {
+    test('shows breach warning when breachWarning is set in sessionStorage', async ({ page }) => {
+        await page.addInitScript(() => sessionStorage.setItem('breachWarning', '1'));
+        await page.goto('/html/profile.html');
+
+        const banner = page.locator('#breach-warning');
+        await expect(banner).toBeVisible();
+        await expect(banner).toContainText('Security alert');
+    });
+
+    test('does not show breach warning without query param', async ({ page }) => {
+        await page.goto('/html/profile.html');
+
+        const banner = page.locator('#breach-warning');
+        await expect(banner).toBeHidden();
+    });
+
+    test('change-password form submit triggers /api/change-password call', async ({ page }) => {
+        await page.route('/api/change-password', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ statusCode: 200, message: 'Password updated successfully' }),
+            })
+        );
+
+        await page.goto('/html/profile.html');
+
+        const requestPromise = page.waitForRequest((req) =>
+            req.url().includes('/api/change-password')
+        );
+
+        await page.fill('#current-password', 'oldpass');
+        await page.fill('#new-password', 'newpass123');
+        await page.fill('#new-password-confirm', 'newpass123');
+        await page.click('#change-password-button');
+
+        const request = await requestPromise;
+        expect(request.method()).toBe('POST');
+
+        const body = JSON.parse(request.postData());
+        expect(body.current_password).toBe('oldpass');
+        expect(body.new_password).toBe('newpass123');
+        expect(body.new_password2).toBe('newpass123');
+    });
+
+    test('change-password form sends Authorization header with token', async ({ page }) => {
+        await page.addInitScript(() => {
+            localStorage.setItem('token', 'test-jwt-token');
+        });
+
+        await page.route('/api/change-password', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ statusCode: 200, message: 'Password updated successfully' }),
+            })
+        );
+
+        await page.goto('/html/profile.html');
+
+        const requestPromise = page.waitForRequest((req) =>
+            req.url().includes('/api/change-password')
+        );
+
+        await page.fill('#current-password', 'old');
+        await page.fill('#new-password', 'new123');
+        await page.fill('#new-password-confirm', 'new123');
+        await page.click('#change-password-button');
+
+        const request = await requestPromise;
+        expect(request.headers()['authorization']).toBe('Bearer test-jwt-token');
+    });
+
+    test('shows error toast on failed password change', async ({ page }) => {
+        await page.route('/api/change-password', (route) =>
+            route.fulfill({
+                status: 401,
+                contentType: 'application/json',
+                body: JSON.stringify({ statusCode: 401, message: 'Current password is incorrect' }),
+            })
+        );
+
+        await page.goto('/html/profile.html');
+
+        await page.fill('#current-password', 'wrong');
+        await page.fill('#new-password', 'new');
+        await page.fill('#new-password-confirm', 'new');
+        await page.click('#change-password-button');
+
+        const toast = page.locator('.toast--error');
+        await expect(toast).toBeVisible();
+        await expect(toast).toContainText('Current password is incorrect');
+    });
+
+    test('breach warning is hidden after successful password change', async ({ page }) => {
+        await page.addInitScript(() => sessionStorage.setItem('breachWarning', '1'));
+
+        await page.route('/api/change-password', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ statusCode: 200, message: 'Password updated successfully' }),
+            })
+        );
+
+        await page.goto('/html/profile.html');
+        await expect(page.locator('#breach-warning')).toBeVisible();
+
+        await page.fill('#current-password', 'old');
+        await page.fill('#new-password', 'new123');
+        await page.fill('#new-password-confirm', 'new123');
+        await page.click('#change-password-button');
+
+        await expect(page.locator('#breach-warning')).toBeHidden();
+    });
+
+    test('nav login link href is /login', async ({ page }) => {
+        await page.goto('/html/profile.html');
+        expect(await page.getAttribute('#nav-login', 'href')).toBe('/login');
+    });
+
+    test('nav register link href is /register', async ({ page }) => {
+        await page.goto('/html/profile.html');
+        expect(await page.getAttribute('#nav-register', 'href')).toBe('/register');
+    });
+});
+
+test.describe('Login page — breach redirect', () => {
+    test('redirects to /profile?breached=1 when breached flag is true', async ({ page }) => {
+        await page.route('/api/login', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    statusCode: 200,
+                    message: 'Login successful',
+                    token: 'fake-jwt',
+                    breached: true,
+                }),
+            })
+        );
+
+        await page.goto('/html/login.html');
+        await page.fill('#username', 'Benthe1954');
+        await page.fill('#password', '^Jt^pLkzW2');
+        await page.click('#login-button');
+
+        await page.waitForURL('**/profile', { timeout: 5000 });
+        expect(page.url()).toContain('/profile');
+    });
+
+    test('redirects to / when breached flag is false', async ({ page }) => {
+        await page.route('/api/login', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    statusCode: 200,
+                    message: 'Login successful',
+                    token: 'fake-jwt',
+                    breached: false,
+                }),
+            })
+        );
+
+        await page.goto('/html/login.html');
+        await page.fill('#username', 'normaluser');
+        await page.fill('#password', 'safepass');
+        await page.click('#login-button');
+
+        await page.waitForURL('**/', { timeout: 5000 });
+        expect(page.url()).toMatch(/\/$/);
+    });
+});


### PR DESCRIPTION
## Summary
- Hardcoded the 20 leaked username/password pairs; login response now includes `breached: true` when a user logs in with a known compromised credential
- Breached users are redirected to `/profile` with a visible security warning banner
- Added `POST /api/change-password` endpoint (JWT-authenticated): verifies current password, hashes and saves new password
- Added Resend email service (`handlers/emailService.go`) using plain `net/http` — no new SDK dependency; sends breach notification emails to all affected users found in the DB; gated by `SEND_BREACH_EMAILS=true` + `RESEND_API_KEY` env vars
- Added `profile.html` + `profile_script.js` with change-password form and breach warning banner
- Added `/profile` Nginx route

## Test plan
- [ ] Unit tests: `isBreached` for all 20 pairs, wrong password, unknown user
- [ ] Integration tests: change-password success/failure (wrong current, mismatch, no token, bad JSON), login `breached` flag set/unset
- [ ] Email service tests: mock Resend server, 4xx error handling, `SendBreachNotificationsToAll` with and without API key
- [ ] Playwright E2E: breach banner shown/hidden, form submission, Authorization header, error toast, breach redirect on login
- [ ] All 23 Playwright tests pass, all Go tests pass

## Environment variables needed in production
| Variable | Purpose |
|---|---|
| `RESEND_API_KEY` | Resend API key |
| `RESEND_FROM_EMAIL` | From address for breach emails |
| `SEND_BREACH_EMAILS=true` | Set once to trigger breach notification send on startup |

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breach flag returned at login and UI flow to warn affected users
  * New profile page with password-change form and client-side validations
  * Client-side "breach lockdown" redirects users with breached credentials to profile
  * Automated breach notification emails sent to affected addresses

* **Tests**
  * End-to-end and unit tests covering breach detection, login redirects, password changes, and notification sending
<!-- end of auto-generated comment: release notes by coderabbit.ai -->