### PR TITLE
perf: reduce POST endpoint latency via bcrypt cost and DB connection pool (#132)

### DIFF
--- a/Go_Refined_Code/database/sqlite.go
+++ b/Go_Refined_Code/database/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"log"
 	"os"
+	"time"
 
 	/* SQL import */
 	_ "github.com/go-sql-driver/mysql"
@@ -37,6 +38,10 @@ func Connect() error {
 	if err := DB.Ping(); err != nil {
 		return err
 	}
+
+	DB.SetMaxOpenConns(25)
+	DB.SetMaxIdleConns(5)
+	DB.SetConnMaxLifetime(5 * time.Minute)
 
 	log.Println("✅ MySQL database connected")
 

--- a/Go_Refined_Code/handlers/authApi.go
+++ b/Go_Refined_Code/handlers/authApi.go
@@ -16,7 +16,7 @@ import (
 var jwtKey = []byte(os.Getenv("JWT_SECRET")) // In production, use os.Getenv("JWT_SECRET")
 
 // bcryptCost is the cost factor for bcrypt hashing. Overridden to bcrypt.MinCost in tests.
-var bcryptCost = 14
+var bcryptCost = 12
 
 // Claims struct that contains the userToken
 type Claims struct {


### PR DESCRIPTION
## Summary
- Reduced bcrypt cost factor from 14 → 12, cutting hash time from ~1.5s to ~0.3s per operation (still OWASP-compliant; existing passwords are unaffected as cost is embedded in stored hashes)
- Added MySQL connection pool configuration (25 max open, 5 idle, 5-min lifetime) to eliminate cold-connection overhead under concurrent load
- Applied `gofmt` to files that were merged without proper formatting

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `docker compose -f compose.dev.yml up -d` — full dev stack starts healthy
- [x] `POST /api/register` — 201, ~0.9s (was ~2s)
- [x] `POST /api/login` — 200 + JWT, ~0.9s (was ~2s)
- [x] `GET /api/search?q=test&language=en` — 200
- [x] `GET /api/weather` — 200
- [x] `GET /api/logout` — 200
- [x] All frontend pages (/, /login.html, /register.html, /about.html, /profile.html) — 200
- [x] Pre-commit hook (golangci-lint + Biome) — 0 issues

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database connection pooling with configuration for improved concurrency handling and connection management.
  * Adjusted password hashing computational efficiency for faster authentication operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->