### PR TITLE
feat: display 'No result on search' when search returns empty (#140)

### DIFF
--- a/Go_Refined_Code/static/javaScript/search_script.js
+++ b/Go_Refined_Code/static/javaScript/search_script.js
@@ -25,6 +25,14 @@ function renderSearchResults(searchResults) {
 
     resultsDiv.innerHTML = ""
 
+    if (!searchResults || searchResults.length === 0) {
+        const noResults = document.createElement("p")
+        noResults.classList.add("no-results")
+        noResults.textContent = "No result on search"
+        resultsDiv.appendChild(noResults)
+        return
+    }
+
     searchResults.forEach(searchResult => {
         const item = document.createElement("div")
         item.classList.add("result-item")


### PR DESCRIPTION
## Summary
- Added a null/empty check in `renderSearchResults` in `search_script.js`
- When the API returns `null` or an empty array, a "No result on search" paragraph is shown in the results area

Closes #140

## Test plan
- [ ] Search for a term with known results — results render as before
- [ ] Search for a nonsense term — "No result on search" message appears
- [ ] All API endpoints respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)