### PR TITLE
Add Prometheus metrics: search query counter and registered users gauge

### DIFF
--- a/Go_Refined_Code/handlers/metrics.go
+++ b/Go_Refined_Code/handlers/metrics.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"database/sql"
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// SearchQueriesTotal counts search queries by term, used for Grafana topk dashboards.
+var SearchQueriesTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "search_queries_total",
+		Help: "Total number of search queries, labelled by the search term.",
+	},
+	[]string{"query"},
+)
+
+var registeredUsersTotal = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "registered_users_total",
+	Help: "Current total number of registered users.",
+})
+
+// StartUserMetricsCollector runs a background goroutine that refreshes
+// DB-backed gauges every interval. Call once from main after DB is ready.
+func StartUserMetricsCollector(db *sql.DB, interval time.Duration) {
+	go func() {
+		for {
+			var count float64
+			if err := db.QueryRow("SELECT COUNT(*) FROM users").Scan(&count); err != nil {
+				slog.Error("metrics: failed to count users", slog.Any("error", err))
+			} else {
+				registeredUsersTotal.Set(count)
+			}
+			time.Sleep(interval)
+		}
+	}()
+}

--- a/Go_Refined_Code/handlers/searchApi.go
+++ b/Go_Refined_Code/handlers/searchApi.go
@@ -96,6 +96,7 @@ LIMIT 20
 			slog.String("language", language),
 			slog.Int("result_count", len(results)),
 		)
+		SearchQueriesTotal.WithLabelValues(q).Inc()
 
 		response := SearchResponse{Data: results}
 

--- a/Go_Refined_Code/main.go
+++ b/Go_Refined_Code/main.go
@@ -32,6 +32,7 @@ func main() {
 		log.Fatal(err)
 	}
 	database.PurgeMD5Users()
+	apiHandlers.StartUserMetricsCollector(database.DB, 60*time.Second)
 
 	if os.Getenv("SEND_BREACH_EMAILS") == "true" {
 		go apiHandlers.SendBreachNotificationsToAll(database.DB)


### PR DESCRIPTION
## Summary

- **`search_queries_total`** — a Prometheus counter vec labelled by `query`. Incremented on every successful search in `searchApi.go`. Enables a Grafana topk panel showing the most searched terms over any time window.
- **`registered_users_total`** — a Prometheus gauge that reflects the live count of rows in the `users` table. A background goroutine (started in `main.go`) refreshes it from the DB every 60 seconds.
- `gofmt` applied across all Go files to resolve pre-existing formatting issues caught by the pre-commit lint hook.

## New metric queries for Grafana

| Dashboard | PromQL |
|---|---|
| Top 10 most searched terms (last 24h) | `topk(10, sum by(query)(increase(search_queries_total[24h])))` |
| Total registered users | `registered_users_total` |

## Test plan

- [ ] Hit `/api/search?q=<term>` a few times, confirm `search_queries_total{query="<term>"}` appears at `/metrics` with the correct count
- [ ] Confirm `registered_users_total` appears at `/metrics` and matches the actual user count in the DB
- [ ] Confirm the value updates after adding/removing a user (within 60s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring and metrics collection for search queries.
  * Implemented automatic periodic tracking of registered user counts in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->