### PR TITLE
Add Prometheus HTTP middleware for per-endpoint request metrics

### DIFF
--- a/Go_Refined_Code/handlers/metrics.go
+++ b/Go_Refined_Code/handlers/metrics.go
@@ -2,9 +2,12 @@ package handlers
 
 import (
 	"database/sql"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -22,6 +25,49 @@ var registeredUsersTotal = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "registered_users_total",
 	Help: "Current total number of registered users.",
 })
+
+var httpRequestsTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Total number of HTTP requests by method, path, and status.",
+	},
+	[]string{"method", "path", "status"},
+)
+
+var httpRequestDuration = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "http_request_duration_seconds",
+		Help:    "HTTP request duration in seconds by method, path, and status.",
+		Buckets: prometheus.DefBuckets,
+	},
+	[]string{"method", "path", "status"},
+)
+
+// PrometheusMiddleware records http_requests_total and http_request_duration_seconds
+// for every request. Uses the Gorilla Mux route pattern as the path label to avoid
+// high-cardinality labels from dynamic URL segments.
+func PrometheusMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		wrapped := newResponseWriter(w)
+
+		next.ServeHTTP(wrapped, r)
+
+		// Use the matched route pattern (e.g. /api/search) not the raw URL.
+		route := "unknown"
+		if match := mux.CurrentRoute(r); match != nil {
+			if pattern, err := match.GetPathTemplate(); err == nil {
+				route = pattern
+			}
+		}
+
+		status := fmt.Sprintf("%d", wrapped.statusCode)
+		duration := time.Since(start).Seconds()
+
+		httpRequestsTotal.WithLabelValues(r.Method, route, status).Inc()
+		httpRequestDuration.WithLabelValues(r.Method, route, status).Observe(duration)
+	})
+}
 
 // StartUserMetricsCollector runs a background goroutine that refreshes
 // DB-backed gauges every interval. Call once from main after DB is ready.

--- a/Go_Refined_Code/main.go
+++ b/Go_Refined_Code/main.go
@@ -46,6 +46,7 @@ func main() {
 
 	// API
 	api := r.PathPrefix("/api").Subrouter()
+	api.Use(apiHandlers.PrometheusMiddleware)
 	api.Use(apiHandlers.LoggingMiddleware)
 	api.HandleFunc("/search", apiHandlers.SearchAPIHandler(database.DB)).Methods("GET")
 	api.HandleFunc("/weather", homeHandler).Methods("GET")


### PR DESCRIPTION
## Summary

- New `PrometheusMiddleware` in `handlers/metrics.go` records two metrics on every API request:
  - `http_requests_total{method, path, status}` — counter
  - `http_request_duration_seconds{method, path, status}` — histogram with default buckets
- Middleware is wired to the `/api` subrouter only — `/metrics` is excluded by design, no noise
- Path label uses the **Gorilla Mux route pattern** (e.g. `/api/login`, `/api/search`) not the raw URL, preventing high-cardinality series from dynamic segments
- Failed logins are fully distinguishable: `http_requests_total{method="POST",path="/api/login",status="401"}`

## Expected output at /metrics

```
http_requests_total{method="POST",path="/api/login",status="401"} 3
http_request_duration_seconds_bucket{method="POST",path="/api/login",status="401",le="0.1"} 3
```

## Grafana queries

| Dashboard | PromQL |
|---|---|
| Request rate per endpoint | `sum by(path, method)(rate(http_requests_total[5m]))` |
| Error rate | `sum by(path)(rate(http_requests_total{status=~"4..\|5.."}[5m]))` |
| p95 latency | `histogram_quantile(0.95, sum by(path, le)(rate(http_request_duration_seconds_bucket[5m])))` |
| Failed logins | `rate(http_requests_total{path="/api/login",status="401"}[5m])` |

## Test plan

- [ ] POST `/api/login` with wrong credentials — confirm `status="401"` appears in `/metrics`
- [ ] GET `/api/search?q=test` — confirm `path="/api/search"` label (not raw URL with query string)
- [ ] Hit `/metrics` directly — confirm it does NOT appear as a series in `http_requests_total`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added HTTP request metrics tracking including request counts, response times, and status codes for improved API monitoring and performance visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->