### PR TITLE
Add weather forecast page (Open-Meteo, 30-min cache)

### DIFF
--- a/Go_Refined_Code/handlers/weatherApi.go
+++ b/Go_Refined_Code/handlers/weatherApi.go
@@ -1,2 +1,91 @@
-// Package handlers weather
+// Package handlers weatherApi
 package handlers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	weatherCacheTTL = 30 * time.Minute
+	openMeteoPath   = "/v1/forecast" +
+		"?latitude=55.6761&longitude=12.5683" +
+		"&current=temperature_2m,windspeed_10m,weathercode,is_day" +
+		"&daily=temperature_2m_max,temperature_2m_min,weathercode" +
+		"&timezone=Europe%2FCopenhagen" +
+		"&forecast_days=7"
+)
+
+// openMeteoBaseURL is the Open-Meteo API base. Overridden in tests.
+var openMeteoBaseURL = "https://api.open-meteo.com" //nolint:gochecknoglobals
+
+type weatherCache struct {
+	mu        sync.Mutex
+	data      map[string]any
+	fetchedAt time.Time
+}
+
+var globalWeatherCache weatherCache //nolint:gochecknoglobals
+
+// WeatherAPIHandler handles GET /api/weather.
+// It fetches a 7-day forecast from Open-Meteo (free, no API key required)
+// and caches the result for 30 minutes so all users share a single upstream call.
+func WeatherAPIHandler(w http.ResponseWriter, r *http.Request) {
+	globalWeatherCache.mu.Lock()
+	defer globalWeatherCache.mu.Unlock()
+
+	if globalWeatherCache.data != nil && time.Since(globalWeatherCache.fetchedAt) < weatherCacheTTL {
+		writeWeatherJSON(w, globalWeatherCache.data)
+		return
+	}
+
+	url := openMeteoBaseURL + openMeteoPath //nolint:gosec
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		slog.Error("weatherApi: failed to build request", slog.Any("error", err))
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Error("weatherApi: failed to fetch from Open-Meteo", slog.Any("error", err))
+		http.Error(w, "Failed to fetch weather data", http.StatusBadGateway)
+		return
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			slog.Error("weatherApi: failed to close response body", slog.Any("error", closeErr))
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Error("weatherApi: Open-Meteo returned non-200", slog.Int("status", resp.StatusCode))
+		http.Error(w, "Weather service unavailable", http.StatusBadGateway)
+		return
+	}
+
+	var data map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		slog.Error("weatherApi: failed to decode response", slog.Any("error", err))
+		http.Error(w, "Failed to parse weather data", http.StatusInternalServerError)
+		return
+	}
+
+	globalWeatherCache.data = data
+	globalWeatherCache.fetchedAt = time.Now()
+
+	writeWeatherJSON(w, data)
+}
+
+func writeWeatherJSON(w http.ResponseWriter, data map[string]any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(map[string]any{"data": data}); err != nil {
+		slog.Error("weatherApi: failed to encode response", slog.Any("error", err))
+	}
+}

--- a/Go_Refined_Code/handlers/weather_test.go
+++ b/Go_Refined_Code/handlers/weather_test.go
@@ -1,0 +1,161 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func resetWeatherCache() {
+	globalWeatherCache.mu.Lock()
+	globalWeatherCache.data = nil
+	globalWeatherCache.fetchedAt = time.Time{}
+	globalWeatherCache.mu.Unlock()
+}
+
+func TestWeatherAPIHandler_Success(t *testing.T) {
+	resetWeatherCache()
+
+	mockPayload := map[string]any{
+		"current": map[string]any{
+			"temperature_2m": 15.0,
+			"windspeed_10m":  8.5,
+			"weathercode":    1.0,
+			"is_day":         1.0,
+		},
+		"daily": map[string]any{
+			"time":               []any{"2026-05-19"},
+			"temperature_2m_max": []any{17.0},
+			"temperature_2m_min": []any{10.0},
+			"weathercode":        []any{1.0},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(mockPayload); err != nil {
+			t.Errorf("mock server encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	openMeteoBaseURL = srv.URL
+	t.Cleanup(func() {
+		openMeteoBaseURL = "https://api.open-meteo.com"
+		resetWeatherCache()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/weather", nil)
+	rr := httptest.NewRecorder()
+	WeatherAPIHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", ct)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := resp["data"]; !ok {
+		t.Error("expected 'data' key in response matching StandardResponse schema")
+	}
+}
+
+func TestWeatherAPIHandler_UsesCache(t *testing.T) {
+	resetWeatherCache()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		if err := json.NewEncoder(w).Encode(map[string]any{"cached": true}); err != nil {
+			t.Errorf("mock server encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	openMeteoBaseURL = srv.URL
+	t.Cleanup(func() {
+		openMeteoBaseURL = "https://api.open-meteo.com"
+		resetWeatherCache()
+	})
+
+	for i := range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/api/weather", nil)
+		rr := httptest.NewRecorder()
+		WeatherAPIHandler(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i, rr.Code)
+		}
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected exactly 1 upstream call (cache should serve requests 2 and 3), got %d", callCount)
+	}
+}
+
+func TestWeatherAPIHandler_UpstreamNon200(t *testing.T) {
+	resetWeatherCache()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	openMeteoBaseURL = srv.URL
+	t.Cleanup(func() {
+		openMeteoBaseURL = "https://api.open-meteo.com"
+		resetWeatherCache()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/weather", nil)
+	rr := httptest.NewRecorder()
+	WeatherAPIHandler(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("expected 502 Bad Gateway on upstream error, got %d", rr.Code)
+	}
+}
+
+func TestWeatherAPIHandler_DoesNotCacheOnError(t *testing.T) {
+	resetWeatherCache()
+
+	firstCall := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if firstCall {
+			firstCall = false
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(map[string]any{"recovered": true}); err != nil {
+			t.Errorf("mock server encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	openMeteoBaseURL = srv.URL
+	t.Cleanup(func() {
+		openMeteoBaseURL = "https://api.open-meteo.com"
+		resetWeatherCache()
+	})
+
+	req1 := httptest.NewRequest(http.MethodGet, "/api/weather", nil)
+	rr1 := httptest.NewRecorder()
+	WeatherAPIHandler(rr1, req1)
+	if rr1.Code != http.StatusBadGateway {
+		t.Errorf("first request: expected 502, got %d", rr1.Code)
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/weather", nil)
+	rr2 := httptest.NewRecorder()
+	WeatherAPIHandler(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Errorf("second request: expected 200 after recovery, got %d", rr2.Code)
+	}
+}

--- a/Go_Refined_Code/main.go
+++ b/Go_Refined_Code/main.go
@@ -49,7 +49,7 @@ func main() {
 	api.Use(apiHandlers.PrometheusMiddleware)
 	api.Use(apiHandlers.LoggingMiddleware)
 	api.HandleFunc("/search", apiHandlers.SearchAPIHandler(database.DB)).Methods("GET")
-	api.HandleFunc("/weather", homeHandler).Methods("GET")
+	api.HandleFunc("/weather", apiHandlers.WeatherAPIHandler).Methods("GET")
 	api.HandleFunc("/register", apiHandlers.HandleAPIRegister(database.DB)).Methods("POST")
 	api.HandleFunc("/login", apiHandlers.HandleAPILogin(database.DB)).Methods("POST")
 	api.HandleFunc("/logout", homeHandler).Methods("GET")

--- a/Go_Refined_Code/nginx.conf
+++ b/Go_Refined_Code/nginx.conf
@@ -21,7 +21,7 @@ server {
 
     location /weather {
         root /usr/share/nginx/html;
-        try_files $uri /html/index.html =404;
+        try_files $uri /html/weather.html =404;
     }
 
     location /about {

--- a/Go_Refined_Code/static/html/about.html
+++ b/Go_Refined_Code/static/html/about.html
@@ -19,6 +19,7 @@
         <h1>
           <a href="/">¿Who Knows?</a>
         </h1>
+        <a href="/weather">Weather</a>
         <a id="nav-login" href="/login">Log in</a>
         <a id="nav-register" href="/register">Register</a>
       </nav>

--- a/Go_Refined_Code/static/html/login.html
+++ b/Go_Refined_Code/static/html/login.html
@@ -19,6 +19,7 @@
         <h1>
           <a href="/">¿Who Knows?</a>
         </h1>
+        <a href="/weather">Weather</a>
         <a id="nav-login" href="/login">Log in</a>
         <a id="nav-register" href="/register">Register</a>
       </nav>

--- a/Go_Refined_Code/static/html/profile.html
+++ b/Go_Refined_Code/static/html/profile.html
@@ -19,6 +19,7 @@
         <h1>
           <a href="/">¿Who Knows?</a>
         </h1>
+        <a href="/weather">Weather</a>
         <a id="nav-login" href="/login">Log in</a>
         <a id="nav-register" href="/register">Register</a>
       </nav>

--- a/Go_Refined_Code/static/html/register.html
+++ b/Go_Refined_Code/static/html/register.html
@@ -19,6 +19,7 @@
         <h1>
           <a href="/">¿Who Knows?</a>
         </h1>
+        <a href="/weather">Weather</a>
         <a id="nav-login" href="/login">Log in</a>
         <a id="nav-register" href="/register">Register</a>
       </nav>

--- a/Go_Refined_Code/static/html/weather.html
+++ b/Go_Refined_Code/static/html/weather.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="da">
+<html lang="en">
 
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>¿Who Knows?</title>
+  <title>Weather — ¿Who Knows?</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="../style.css">
@@ -27,18 +27,17 @@
 
     <div class="body">
 
-      <div class="search-hero">
-        <span class="search-hero-eyebrow">Search Engine</span>
-        <h1 class="search-hero-title">¿Who Knows?</h1>
-        <p class="search-hero-sub">The search engine that keeps you guessing.</p>
-
-        <div class="search-bar-wrapper">
-          <input id="search-input" placeholder="Search for anything…" value="" autocomplete="off" />
-          <button id="search-button" type="button">Search</button>
-        </div>
+      <div class="weather-hero">
+        <span class="search-hero-eyebrow">Copenhagen, Denmark</span>
+        <h1 class="search-hero-title">Weather Forecast</h1>
+        <p class="search-hero-sub">Powered by Open-Meteo &mdash; updated every 30 minutes.</p>
       </div>
 
-      <div id="results"></div>
+      <div id="weather-current" class="weather-current">
+        <p class="weather-loading">Loading weather&hellip;</p>
+      </div>
+
+      <div id="weather-forecast" class="weather-forecast"></div>
 
       <div class="footer">
         <span>¿Who Knows? &copy; 2026</span>
@@ -46,8 +45,9 @@
       </div>
     </div>
 
-    <script src="../javaScript/search_script.js" type="module"></script>
+    <script src="../javaScript/weather_script.js" type="module"></script>
   </div>
+
 </body>
 
 </html>

--- a/Go_Refined_Code/static/javaScript/weather_script.js
+++ b/Go_Refined_Code/static/javaScript/weather_script.js
@@ -1,0 +1,105 @@
+import { checkIfLoggedIn } from "./reuseable_functions.js"
+import { showError } from "./reuseable_functions.js"
+
+checkIfLoggedIn()
+
+const WMO_DESCRIPTION = {
+    0: "Clear sky",
+    1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+    45: "Foggy", 48: "Icy fog",
+    51: "Light drizzle", 53: "Moderate drizzle", 55: "Dense drizzle",
+    61: "Slight rain", 63: "Moderate rain", 65: "Heavy rain",
+    71: "Slight snow", 73: "Moderate snow", 75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight showers", 81: "Moderate showers", 82: "Violent showers",
+    85: "Slight snow showers", 86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with hail", 99: "Thunderstorm with heavy hail",
+}
+
+const WMO_ICON = {
+    0: "☀️",
+    1: "🌤️", 2: "⛅", 3: "☁️",
+    45: "🌫️", 48: "🌫️",
+    51: "🌦️", 53: "🌦️", 55: "🌧️",
+    61: "🌧️", 63: "🌧️", 65: "🌧️",
+    71: "🌨️", 73: "🌨️", 75: "❄️",
+    77: "❄️",
+    80: "🌦️", 81: "🌧️", 82: "⛈️",
+    85: "🌨️", 86: "❄️",
+    95: "⛈️",
+    96: "⛈️", 99: "⛈️",
+}
+
+function wmoDescription(code) {
+    return WMO_DESCRIPTION[code] ?? "Unknown"
+}
+
+function wmoIcon(code) {
+    return WMO_ICON[code] ?? "🌡️"
+}
+
+function formatDate(dateStr) {
+    const d = new Date(dateStr + "T12:00:00")
+    return d.toLocaleDateString("en-GB", { weekday: "short", month: "short", day: "numeric" })
+}
+
+function renderCurrent(current) {
+    const container = document.getElementById("weather-current")
+    const code = current.weathercode
+
+    container.innerHTML = `
+        <div class="weather-now-card">
+            <div class="weather-now-icon">${wmoIcon(code)}</div>
+            <div class="weather-now-info">
+                <div class="weather-now-temp">${Math.round(current.temperature_2m)}<span class="weather-unit">°C</span></div>
+                <div class="weather-now-desc">${wmoDescription(code)}</div>
+                <div class="weather-now-wind">Wind: ${Math.round(current.windspeed_10m)} km/h</div>
+            </div>
+        </div>
+    `
+}
+
+function renderForecast(daily) {
+    const container = document.getElementById("weather-forecast")
+    const { time, temperature_2m_max, temperature_2m_min, weathercode } = daily
+
+    container.innerHTML = `<h2 class="weather-forecast-title">7-Day Forecast</h2>`
+
+    const grid = document.createElement("div")
+    grid.className = "weather-grid"
+
+    time.forEach((date, i) => {
+        const card = document.createElement("div")
+        card.className = "weather-day-card"
+        card.innerHTML = `
+            <div class="weather-day-date">${formatDate(date)}</div>
+            <div class="weather-day-icon">${wmoIcon(weathercode[i])}</div>
+            <div class="weather-day-desc">${wmoDescription(weathercode[i])}</div>
+            <div class="weather-day-temps">
+                <span class="weather-temp-high">${Math.round(temperature_2m_max[i])}°</span>
+                <span class="weather-temp-low">${Math.round(temperature_2m_min[i])}°</span>
+            </div>
+        `
+        grid.appendChild(card)
+    })
+
+    container.appendChild(grid)
+}
+
+fetch("/api/weather")
+    .then(res => {
+        if (!res.ok) throw new Error(`Weather API returned ${res.status}`)
+        return res.json()
+    })
+    .then(json => {
+        const weather = json.data
+        renderCurrent(weather.current)
+        renderForecast(weather.daily)
+    })
+    .catch(err => {
+        console.error("Weather fetch failed:", err)
+        showError("Could not load weather data. Please try again later.")
+        document.getElementById("weather-current").innerHTML =
+            `<p class="weather-loading">Weather unavailable.</p>`
+    })

--- a/Go_Refined_Code/static/style.css
+++ b/Go_Refined_Code/static/style.css
@@ -656,6 +656,76 @@ ul.flashes li {
   margin-top: 5px;
 }
 
+/* ── Weather ── */
+.weather-hero { padding: 56px 24px 32px; text-align: center; }
+
+.weather-current {
+  max-width: 480px;
+  margin: 0 auto 40px;
+  padding: 0 24px;
+}
+
+.weather-now-card {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-mid);
+  border-radius: var(--radius-lg);
+  padding: 28px 32px;
+}
+
+.weather-now-icon { font-size: 64px; line-height: 1; }
+
+.weather-now-temp {
+  font-family: var(--font-serif);
+  font-size: 52px;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1;
+}
+
+.weather-unit { font-size: 28px; color: var(--text-2); }
+.weather-now-desc { font-size: 16px; color: var(--text-1); margin-top: 6px; }
+.weather-now-wind { font-size: 13px; color: var(--text-2); margin-top: 4px; font-family: var(--font-mono); }
+
+.weather-loading { color: var(--text-2); text-align: center; padding: 40px 0; }
+
+.weather-forecast { max-width: 900px; margin: 0 auto 60px; padding: 0 24px; }
+
+.weather-forecast-title {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  color: var(--text-2);
+  margin-bottom: 16px;
+  font-weight: 500;
+}
+
+.weather-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 12px;
+}
+
+.weather-day-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 12px;
+  text-align: center;
+  transition: border-color var(--t) var(--ease);
+}
+
+.weather-day-card:hover { border-color: var(--border-mid); }
+
+.weather-day-date { font-size: 11px; color: var(--text-2); margin-bottom: 8px; font-family: var(--font-mono); }
+.weather-day-icon { font-size: 28px; margin-bottom: 6px; }
+.weather-day-desc { font-size: 11px; color: var(--text-2); margin-bottom: 8px; line-height: 1.3; }
+
+.weather-day-temps { display: flex; justify-content: center; gap: 8px; font-family: var(--font-mono); }
+.weather-temp-high { color: var(--accent); font-size: 13px; font-weight: 500; }
+.weather-temp-low { color: var(--text-3); font-size: 13px; }
+
 /* ── Responsive ── */
 @media (max-width: 600px) {
   nav { padding: 0 16px; }

--- a/Go_Refined_Code/static/style.css
+++ b/Go_Refined_Code/static/style.css
@@ -691,7 +691,7 @@ ul.flashes li {
 
 .weather-loading { color: var(--text-2); text-align: center; padding: 40px 0; }
 
-.weather-forecast { max-width: 900px; margin: 0 auto 60px; padding: 0 24px; }
+.weather-forecast { width: 100%; max-width: 900px; margin: 0 auto 60px; padding: 0 24px; box-sizing: border-box; }
 
 .weather-forecast-title {
   font-family: var(--font-serif);
@@ -702,12 +702,14 @@ ul.flashes li {
 }
 
 .weather-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  display: flex;
   gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 6px;
 }
 
 .weather-day-card {
+  flex: 1 0 110px;
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);

--- a/Go_Refined_Code/tests/e2e/docker-tests/weather.docker.spec.js
+++ b/Go_Refined_Code/tests/e2e/docker-tests/weather.docker.spec.js
@@ -1,0 +1,94 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Weather integration tests — run against the live Docker Compose stack.
+ *
+ * These tests make real HTTP requests through the full chain:
+ *   Browser → Nginx (8081) → Go backend (8080) → Open-Meteo API
+ *
+ * No API mocking. The intent is to verify:
+ *  1. Nginx routes /weather to the correct HTML file.
+ *  2. Nginx proxies /api/weather to the Go backend correctly.
+ *  3. The Go backend returns a valid StandardResponse JSON.
+ *  4. The frontend renders the data without errors.
+ */
+
+test.describe('Weather — full stack integration', () => {
+    test('GET /weather serves the weather HTML page', async ({ page }) => {
+        const response = await page.goto('/weather');
+        expect(response.status()).toBe(200);
+        const title = await page.title();
+        expect(title).toContain('Weather');
+    });
+
+    test('GET /api/weather returns valid StandardResponse JSON', async ({ request }) => {
+        const response = await request.get('/api/weather');
+        expect(response.status()).toBe(200);
+        expect(response.headers()['content-type']).toContain('application/json');
+
+        const body = await response.json();
+        expect(body).toHaveProperty('data');
+        expect(body.data).toHaveProperty('current');
+        expect(body.data).toHaveProperty('daily');
+
+        const { current, daily } = body.data;
+        expect(typeof current.temperature_2m).toBe('number');
+        expect(typeof current.windspeed_10m).toBe('number');
+        expect(typeof current.weathercode).toBe('number');
+        expect(Array.isArray(daily.time)).toBe(true);
+        expect(daily.time.length).toBe(7);
+        expect(daily.temperature_2m_max.length).toBe(7);
+        expect(daily.temperature_2m_min.length).toBe(7);
+        expect(daily.weathercode.length).toBe(7);
+    });
+
+    test('weather page renders current temperature after real API call', async ({ page }) => {
+        await page.goto('/weather');
+        // Wait for the JS to fetch and render — loading placeholder disappears
+        await expect(page.locator('.weather-now-card')).toBeVisible({ timeout: 10000 });
+        // Temperature should be a number (we don't know exact value)
+        const tempText = await page.locator('.weather-now-temp').textContent();
+        expect(tempText).toMatch(/-?\d+/);
+    });
+
+    test('weather page renders 7 forecast cards after real API call', async ({ page }) => {
+        await page.goto('/weather');
+        await expect(page.locator('.weather-day-card').first()).toBeVisible({ timeout: 10000 });
+        await expect(page.locator('.weather-day-card')).toHaveCount(7);
+    });
+
+    test('second API call is served from cache (response time < 100ms)', async ({ request }) => {
+        // First call — may hit Open-Meteo
+        await request.get('/api/weather');
+
+        // Second call — must be served from cache and be very fast
+        const start = Date.now();
+        const response = await request.get('/api/weather');
+        const duration = Date.now() - start;
+
+        expect(response.status()).toBe(200);
+        expect(duration).toBeLessThan(100);
+    });
+
+    test('Nginx routes /login to the login page', async ({ page }) => {
+        const response = await page.goto('/login');
+        expect(response.status()).toBe(200);
+        await expect(page.locator('#login-form')).toBeVisible();
+    });
+
+    test('Nginx routes /register to the register page', async ({ page }) => {
+        const response = await page.goto('/register');
+        expect(response.status()).toBe(200);
+    });
+
+    test('Nginx routes /about to the about page', async ({ page }) => {
+        const response = await page.goto('/about');
+        expect(response.status()).toBe(200);
+    });
+
+    test('Nginx returns 404 for undefined routes', async ({ request }) => {
+        const response = await request.get('/this-route-does-not-exist');
+        expect(response.status()).toBe(404);
+    });
+});

--- a/Go_Refined_Code/tests/e2e/playwright.docker.config.js
+++ b/Go_Refined_Code/tests/e2e/playwright.docker.config.js
@@ -1,0 +1,20 @@
+// @ts-check
+const { defineConfig } = require('@playwright/test');
+
+/**
+ * Docker Compose integration test config.
+ *
+ * Run against the full running stack (Nginx + Go + MySQL):
+ *   docker compose -f compose.dev.yml up -d
+ *   npx playwright test --config=playwright.docker.config.js
+ *
+ * Unlike the default config, there is no webServer here — the stack must
+ * already be running. Tests navigate through Nginx (port 8081) so routing,
+ * API proxying, and the Go backend are all exercised for real.
+ */
+module.exports = defineConfig({
+    testDir: './docker-tests',
+    use: {
+        baseURL: 'http://localhost:8081',
+    },
+});

--- a/Go_Refined_Code/tests/e2e/tests/weather.spec.js
+++ b/Go_Refined_Code/tests/e2e/tests/weather.spec.js
@@ -1,0 +1,117 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const MOCK_WEATHER = {
+    data: {
+        current: {
+            temperature_2m: 18.5,
+            windspeed_10m: 12.3,
+            weathercode: 2,
+            is_day: 1,
+        },
+        daily: {
+            time: ['2026-05-19', '2026-05-20', '2026-05-21', '2026-05-22', '2026-05-23', '2026-05-24', '2026-05-25'],
+            temperature_2m_max: [20, 18, 15, 17, 19, 21, 16],
+            temperature_2m_min: [12, 10, 8, 11, 13, 14, 9],
+            weathercode: [2, 61, 3, 1, 0, 2, 80],
+        },
+    },
+};
+
+test.describe('Weather page', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('/api/weather', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(MOCK_WEATHER),
+            })
+        );
+        await page.goto('/html/weather.html');
+    });
+
+    test('shows current temperature', async ({ page }) => {
+        await expect(page.locator('.weather-now-temp')).toBeVisible();
+        // 18.5 rounds to 19 (Math.round)
+        await expect(page.locator('.weather-now-temp')).toContainText('19');
+    });
+
+    test('shows current weather condition', async ({ page }) => {
+        await expect(page.locator('.weather-now-desc')).toContainText('Partly cloudy');
+    });
+
+    test('shows wind speed', async ({ page }) => {
+        await expect(page.locator('.weather-now-wind')).toContainText('12 km/h');
+    });
+
+    test('renders 7 forecast day cards', async ({ page }) => {
+        await expect(page.locator('.weather-day-card')).toHaveCount(7);
+    });
+
+    test('first forecast card shows correct high and low temperatures', async ({ page }) => {
+        const firstCard = page.locator('.weather-day-card').first();
+        await expect(firstCard.locator('.weather-temp-high')).toContainText('20°');
+        await expect(firstCard.locator('.weather-temp-low')).toContainText('12°');
+    });
+
+    test('second forecast card shows rain condition', async ({ page }) => {
+        // weathercode 61 = "Slight rain"
+        const secondCard = page.locator('.weather-day-card').nth(1);
+        await expect(secondCard.locator('.weather-day-desc')).toContainText('Slight rain');
+    });
+
+    test('weather nav link is present and points to /weather', async ({ page }) => {
+        await expect(page.locator('nav a[href="/weather"]')).toBeVisible();
+    });
+});
+
+test.describe('Weather page — API error handling', () => {
+    test('shows fallback message when API returns 500', async ({ page }) => {
+        await page.route('/api/weather', (route) =>
+            route.fulfill({ status: 500, body: 'Internal Server Error' })
+        );
+        await page.goto('/html/weather.html');
+
+        await expect(page.locator('.weather-loading')).toContainText('Weather unavailable');
+        await expect(page.locator('.toast--error')).toBeVisible();
+    });
+
+    test('shows error toast with message when API returns 502', async ({ page }) => {
+        await page.route('/api/weather', (route) =>
+            route.fulfill({ status: 502, body: 'Bad Gateway' })
+        );
+        await page.goto('/html/weather.html');
+
+        const toast = page.locator('.toast--error');
+        await expect(toast).toBeVisible();
+        await expect(toast).toContainText('Could not load weather data');
+    });
+});
+
+test.describe('Weather nav link on all pages', () => {
+    test('index page has weather nav link', async ({ page }) => {
+        await page.goto('/html/index.html');
+        await expect(page.locator('nav a[href="/weather"]')).toBeVisible();
+    });
+
+    test('login page has weather nav link', async ({ page }) => {
+        await page.goto('/html/login.html');
+        await expect(page.locator('nav a[href="/weather"]')).toBeVisible();
+    });
+
+    test('register page has weather nav link', async ({ page }) => {
+        await page.goto('/html/register.html');
+        await expect(page.locator('nav a[href="/weather"]')).toBeVisible();
+    });
+
+    test('about page has weather nav link', async ({ page }) => {
+        await page.goto('/html/about.html');
+        await expect(page.locator('nav a[href="/weather"]')).toBeVisible();
+    });
+
+    test('profile page has weather nav link', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('token', 'fake-jwt'));
+        await page.goto('/html/profile.html');
+        await expect(page.locator('nav a[href="/weather"]')).toBeVisible();
+    });
+});

--- a/docs/backend/weather.md
+++ b/docs/backend/weather.md
@@ -1,0 +1,134 @@
+# Weather — weatherApi.go
+
+**File:** `Go_Refined_Code/handlers/weatherApi.go`
+
+Handles `GET /api/weather`. Fetches a 7-day weather forecast from [Open-Meteo](https://open-meteo.com) and returns it wrapped in the `StandardResponse` shape defined by the OpenAPI spec (`Legacy/openApiSpec`).
+
+---
+
+## Why Open-Meteo?
+
+- **Free** — no API key required, no billing setup.
+- **Generous limits** — 10,000 requests per day on the free tier.
+- **Open data** — based on publicly funded meteorological data.
+- **Stable API** — has a published OpenAPI spec and versioned endpoints.
+
+---
+
+## Response Format
+
+Matches the `StandardResponse` schema from the legacy OpenAPI spec:
+
+```json
+{
+  "data": {
+    "current": {
+      "temperature_2m": 14.5,
+      "windspeed_10m": 9.2,
+      "weathercode": 2,
+      "is_day": 1
+    },
+    "daily": {
+      "time": ["2026-05-19", "2026-05-20", ...],
+      "temperature_2m_max": [17.1, 15.8, ...],
+      "temperature_2m_min": [10.2, 9.7, ...],
+      "weathercode": [2, 61, ...]
+    }
+  }
+}
+```
+
+The `data` object is the raw Open-Meteo response. The frontend interprets the WMO weather codes into human-readable descriptions and emoji icons.
+
+---
+
+## In-Memory Cache
+
+The most important part of this handler is the 30-minute cache.
+
+```
+Request 1 → cache miss → fetch Open-Meteo → store in cache → respond
+Request 2 → cache hit  → respond from cache (no upstream call)
+...
+Request N → cache hit  → respond from cache (no upstream call)
+30 min later → cache expired
+Request N+1 → cache miss → fetch Open-Meteo → store in cache → respond
+```
+
+### How it works
+
+```go
+type weatherCache struct {
+    mu        sync.Mutex
+    data      map[string]any
+    fetchedAt time.Time
+}
+
+var globalWeatherCache weatherCache
+```
+
+The mutex ensures that concurrent requests don't trigger multiple simultaneous upstream calls. When the cache has valid data (`fetchedAt` is less than 30 minutes ago), the handler returns immediately without touching Open-Meteo.
+
+### Scalability impact
+
+Without cache: 1,000 users/minute = 1,000 Open-Meteo requests/minute (~1.4M/day — far over the free tier limit).
+
+With 30-minute cache: 1,000 users/minute = 2 Open-Meteo requests/hour = 48/day. Well within limits at any traffic level.
+
+---
+
+## Open-Meteo Parameters
+
+The handler fetches weather for **Copenhagen** (hardcoded coordinates):
+
+| Parameter | Value |
+|---|---|
+| Latitude | 55.6761 |
+| Longitude | 12.5683 |
+| Timezone | Europe/Copenhagen |
+| Forecast days | 7 |
+| Current fields | `temperature_2m`, `windspeed_10m`, `weathercode`, `is_day` |
+| Daily fields | `temperature_2m_max`, `temperature_2m_min`, `weathercode` |
+
+---
+
+## Functions
+
+### `WeatherAPIHandler(w, r)`
+
+The exported handler registered in `main.go` for `GET /api/weather`.
+
+1. Acquires the cache mutex.
+2. If the cache is valid, calls `writeWeatherJSON` and returns immediately.
+3. Otherwise, builds an HTTP request to Open-Meteo using the request's context (so cancellations propagate correctly).
+4. Returns `502 Bad Gateway` if Open-Meteo is unreachable or returns a non-200 status.
+5. Decodes the JSON response, stores it in the cache with the current timestamp, and responds.
+
+### `writeWeatherJSON(w, data)`
+
+Private helper that wraps `data` in `{ "data": ... }` and writes it as JSON. Matches the `StandardResponse` schema.
+
+---
+
+## Testing — weather_test.go
+
+Four tests using a local `httptest.Server` as a mock for Open-Meteo. The `openMeteoBaseURL` variable is overridden to point to the mock server, and `globalWeatherCache` is reset between tests.
+
+| Test | What it verifies |
+|---|---|
+| `TestWeatherAPIHandler_Success` | Returns 200 with a `{ "data": ... }` response body |
+| `TestWeatherAPIHandler_UsesCache` | Three requests trigger only one upstream call |
+| `TestWeatherAPIHandler_UpstreamNon200` | A 503 from Open-Meteo results in a 502 to the client |
+| `TestWeatherAPIHandler_DoesNotCacheOnError` | A failed fetch does not poison the cache — the next request retries |
+
+---
+
+## Error Handling
+
+| Situation | Response |
+|---|---|
+| Failed to build request | `500 Internal Server Error` |
+| Network error to Open-Meteo | `502 Bad Gateway` |
+| Open-Meteo returns non-200 | `502 Bad Gateway` |
+| Failed to decode JSON | `500 Internal Server Error` |
+| Cache hit | `200 OK` (no upstream call) |

--- a/docs/frontend/weather.md
+++ b/docs/frontend/weather.md
@@ -1,0 +1,74 @@
+# Weather Page — weather.html & weather_script.js
+
+**Files:**
+- `Go_Refined_Code/static/html/weather.html`
+- `Go_Refined_Code/static/javaScript/weather_script.js`
+
+The weather page displays the current conditions and a 7-day forecast for Copenhagen, fetched from the Go backend which proxies and caches Open-Meteo data.
+
+---
+
+## weather.html
+
+**URL:** `/weather`
+
+A static HTML page that loads `weather_script.js` to populate two sections:
+
+- **`#weather-current`** — current conditions card (temperature, wind, condition).
+- **`#weather-forecast`** — 7-day forecast grid, one card per day.
+
+The page shows a "Loading weather…" placeholder until the API responds.
+
+---
+
+## weather_script.js
+
+Calls `GET /api/weather` on page load and renders the response into the DOM.
+
+### WMO Weather Code Interpretation
+
+Open-Meteo returns WMO weather interpretation codes (integers) rather than text descriptions. The script maps these to human-readable strings and emoji icons:
+
+| Code range | Condition | Icon |
+|---|---|---|
+| 0 | Clear sky | ☀️ |
+| 1–3 | Clear / partly cloudy / overcast | 🌤️ ⛅ ☁️ |
+| 45, 48 | Fog | 🌫️ |
+| 51–55 | Drizzle | 🌦️ |
+| 61–65 | Rain | 🌧️ |
+| 71–77 | Snow | 🌨️ ❄️ |
+| 80–82 | Rain showers | 🌦️ ⛈️ |
+| 95–99 | Thunderstorm | ⛈️ |
+
+### `renderCurrent(current)`
+
+Reads `current.temperature_2m`, `current.windspeed_10m`, and `current.weathercode` from the API response and builds the current-conditions card.
+
+### `renderForecast(daily)`
+
+Reads `daily.time`, `daily.temperature_2m_max`, `daily.temperature_2m_min`, and `daily.weathercode` (all arrays with one entry per day) and builds one card per day in a CSS grid.
+
+### `formatDate(dateStr)`
+
+Converts an ISO date string (`"2026-05-19"`) to a short, readable label (`"Mon, 19 May"`) using the browser's `Intl`-based `toLocaleDateString`.
+
+### Error handling
+
+If the fetch fails or the API returns an error status, `showError()` from `reuseable_functions.js` shows a toast notification and a fallback "Weather unavailable." message replaces the loading placeholder.
+
+---
+
+## Data Flow
+
+```
+weather.html loads
+    └── weather_script.js runs
+        └── fetch("/api/weather")
+            └── Nginx proxies to Go backend
+                └── WeatherAPIHandler
+                    ├── Cache hit  → return cached data
+                    └── Cache miss → fetch Open-Meteo → cache → return
+            └── { "data": { current: {...}, daily: {...} } }
+        └── renderCurrent(data.current)
+        └── renderForecast(data.daily)
+```


### PR DESCRIPTION
## Summary

- Implements the Consumer Report assignment: a weather page displaying the 7-day Copenhagen forecast
- Uses **Open-Meteo** (free, no API key, open data) as the 3rd-party weather service
- Backend fetches and caches the result for **30 minutes** — all users share one upstream call regardless of traffic volume (solves the scalability requirement)
- Response shape matches the `StandardResponse` schema from `Legacy/openApiSpec`

## What changed

| Area | Change |
|---|---|
| `handlers/weatherApi.go` | Full implementation: Open-Meteo fetch + in-memory cache |
| `handlers/weather_test.go` | 4 tests: success, cache hit, upstream error, no cache poisoning on error |
| `main.go` | Wire `WeatherAPIHandler` instead of the placeholder stub |
| `nginx.conf` | Serve `weather.html` for `/weather` route |
| `static/html/weather.html` | New weather page |
| `static/javaScript/weather_script.js` | WMO code → text + emoji, renders current + 7-day forecast |
| `static/style.css` | Weather card and grid styles matching the existing design system |
| All HTML nav bars | Added Weather link for discoverability |
| `docs/backend/weather.md` | Backend docs including cache design and scalability notes |
| `docs/frontend/weather.md` | Frontend page and JS module docs |

## Scalability answer

Without cache: N users × refresh rate = N Open-Meteo API calls.
With 30-min cache: regardless of user count, only **1 call per 30 minutes** hits Open-Meteo. Stays well within the free tier (10,000/day) at any realistic traffic volume.

## Test plan

- [ ] `go test ./...` passes
- [ ] Navigate to `/weather` — current temperature, condition, and 7-day grid display correctly
- [ ] Navigate away and back — second load is instant (served from cache, no upstream call in logs)
- [ ] Check Go logs — `weatherApi:` log entries only appear once per 30 minutes
- [ ] Weather nav link visible on all pages