### PR TITLE
Fix DAST job: start MySQL before backend

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -60,17 +60,43 @@ jobs:
       - name: Load backend image
         run: docker load < backend.tar.gz
 
+      - name: Start MySQL
+        run: |
+          docker run -d --name mysql \
+            -e MYSQL_ROOT_PASSWORD=root \
+            -e MYSQL_DATABASE=whoknows \
+            -e MYSQL_USER=app \
+            -e MYSQL_PASSWORD=app \
+            -p 3306:3306 \
+            mysql:8 --default-authentication-plugin=mysql_native_password
+
+      - name: Wait for MySQL to be ready
+        run: |
+          for i in $(seq 1 20); do
+            if docker exec mysql mysqladmin ping -h localhost -u root -proot --silent 2>/dev/null; then
+              echo "MySQL ready"
+              break
+            fi
+            echo "Attempt $i/20 - waiting for MySQL..."
+            sleep 3
+          done
+
       - name: Start backend
-        run: docker run -d -p 8080:8080 --name backend ${{ env.BACKEND_IMAGE }}:local
+        run: |
+          docker run -d -p 8080:8080 --name backend \
+            --link mysql:mysql \
+            -e DATABASE_PATH="app:app@tcp(mysql:3306)/whoknows?parseTime=true" \
+            -e JWT_SECRET=dast-test-secret \
+            ${{ env.BACKEND_IMAGE }}:local
 
       - name: Wait for app to be ready
         run: |
-          for i in $(seq 1 15); do
+          for i in $(seq 1 20); do
             if curl -sf http://localhost:8080; then
               echo "App ready"
               break
             fi
-            echo "Attempt $i/15 - waiting..."
+            echo "Attempt $i/20 - waiting..."
             sleep 3
           done
 


### PR DESCRIPTION
## Summary
- DAST job was failing with docker exit code 3 because the backend crashes immediately without a database connection
- Added MySQL container startup before the backend in the DAST job
- Backend now has a live database to connect to, giving ZAP a running target to scan

## Test plan
- [ ] CD pipeline DAST job completes without docker exit code 3
- [ ] ZAP scan reaches a live `http://localhost:8080` target
- [ ] Push job runs after DAST succeeds