### PR TITLE
Fix compose: admin env vars and mysql:8.0

### DIFF
--- a/Go_Refined_Code/compose.dev.yml
+++ b/Go_Refined_Code/compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     container_name: mysql
     ports:
       - "127.0.0.1:3307:3306"

--- a/Go_Refined_Code/compose.yml
+++ b/Go_Refined_Code/compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     container_name: mysql
     ports:
       - "127.0.0.1:3306:3306"
@@ -48,6 +48,9 @@ services:
         condition: service_healthy
     environment:
       DATABASE_PATH: ${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(mysql:3306)/${MYSQL_DATABASE}?parseTime=true
+      ADMIN_USERNAME: ${ADMIN_USERNAME}
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       SCRAPER_KEY: ${SCRAPER_KEY}
       SCRAPE_KEY: ${SCRAPE_KEY}
       SCRAPE_FUNCTION_URL: ${SCRAPE_FUNCTION_URL}


### PR DESCRIPTION
Add missing ADMIN_USERNAME/EMAIL/PASSWORD to compose.yml and pin mysql to 8.0 in both compose files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MySQL service image to version 8.0 for improved stability
  * Added administrative credentials configuration for backend services

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gorillaerne/Devops_Gorillas/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->