### PR TITLE
Revert compose mysql to :8

### DIFF
--- a/Go_Refined_Code/compose.dev.yml
+++ b/Go_Refined_Code/compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8.0
+    image: mysql:8
     container_name: mysql
     ports:
       - "127.0.0.1:3307:3306"

--- a/Go_Refined_Code/compose.yml
+++ b/Go_Refined_Code/compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8.0
+    image: mysql:8
     container_name: mysql
     ports:
       - "127.0.0.1:3306:3306"


### PR DESCRIPTION
The production data volume was initialized with MySQL 8.4. Pinning to 8.0 caused a downgrade error. CI uses 8.0 with a fresh volume so that's fine to keep.